### PR TITLE
GH#18: docs: record dashboard refresh recovery

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -80,7 +80,8 @@ Format: `- [ ] tNNN Description @owner #tag ~estimate risk:level logged:date`
 
 ## Done
 
-<!--TOON:done[0]{id,desc,owner,tags,est,actual,logged,started,completed,status}:
+<!--TOON:done[1]{id,desc,owner,tags,est,actual,logged,started,completed,status}:
+- t001 Document supervisor dashboard refresh recovery @superdav42 #ops #dashboard ~15m actual:15m logged:2026-05-31 started:2026-05-31 completed:2026-05-31 status:done
 -->
 
 ## Declined
@@ -99,5 +100,5 @@ Format: `- [ ] tNNN Description @owner #tag ~estimate risk:level logged:date`
 <!--/TOON:subtasks-->
 
 <!--TOON:summary{total,ready,pending,in_progress,in_review,done,declined,total_est,total_actual}:
-0,0,0,0,0,0,0,,
+1,0,0,0,0,1,0,15m,15m
 -->


### PR DESCRIPTION
## Summary

Restored the supervisor dashboard #8 last_refresh marker and recorded the operational recovery in TODO.md.

## Files Changed

TODO.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check HEAD~1..HEAD; gh api repos/Ultimate-Multisite/ultimate-ai-plugin-translations/issues/8 --jq '{updated_at, has_last_refresh: (.body|test("last_refresh: [0-9]{4}-[0-9]{2}-[0-9]{2}T")), last_refresh: ((.body|match("last_refresh: [^\\n]+"))?.string // null)}'

Resolves #18


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.6 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 6m and 47,347 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project task tracking documentation with completed task records and time estimates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->