### PR TITLE
GH#24: docs: document dashboard freshness checks

### DIFF
--- a/DASHBOARD_FRESHNESS.md
+++ b/DASHBOARD_FRESHNESS.md
@@ -1,0 +1,32 @@
+# Supervisor Dashboard Freshness
+
+This repository has two aidevops-maintained dashboard issues with different
+purposes:
+
+- Issue #8 is the legacy queue health dashboard. It reports supervisor queue
+  state and can remain unchanged when the repo has no active PRs, assigned
+  issues, auto-dispatch work, or workers.
+- Issue #17 is the current code audit routines dashboard. It is updated by the
+  daily quality sweep and should be used for code-audit freshness checks.
+
+When a freshness alert references issue #8, verify both surfaces before treating
+the scheduler as broken:
+
+```bash
+gh issue view 8 --repo Ultimate-Multisite/ultimate-ai-plugin-translations \
+  --json title,state,updatedAt,body
+gh issue view 17 --repo Ultimate-Multisite/ultimate-ai-plugin-translations \
+  --json title,state,updatedAt,body
+```
+
+Expected healthy evidence from `~/.aidevops/logs/stats.log` is an hourly
+`[stats-wrapper] Finished` entry and a health-refresh line like:
+
+```text
+[stats] Health issue: skipping creation for Ultimate-Multisite/ultimate-ai-plugin-translations — no active PRs, assigned issues, auto-dispatch work, or workers
+[stats] Health issues: updated 15 repo(s)
+```
+
+If issue #8 is stale but the log shows the skip line above and issue #17 has a
+recent `Last sweep`, the scheduler is running; the stale queue dashboard is a
+legacy/inactive-work signal rather than a plugin code defect.


### PR DESCRIPTION
## Summary

Documented the distinction between the legacy queue dashboard (#8) and the current code audit dashboard (#17), including scheduler log evidence that shows health refresh skips inactive repos while the stats wrapper continues running.

## Files Changed

DASHBOARD_FRESHNESS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified commit 38028af is present; checked issue #8 updatedAt=2026-06-04T16:15:40Z with last_refresh marker present; checked issue #17 Last sweep=2026-06-04T10:37:50Z; checked API rate limits core remaining=4649 and graphql remaining=3695.

Resolves #24


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.12 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 5m and 94,469 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for interpreting supervisor dashboard health indicators and verifying scheduler operational status. Coverage includes methods for analyzing health logs, interpreting GitHub issue information, and guidance for handling cases where dashboard information freshness differs from actual operational status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->