### PR TITLE
GH#26: docs: document dashboard stale root cause

### DIFF
--- a/DASHBOARD_FRESHNESS.md
+++ b/DASHBOARD_FRESHNESS.md
@@ -30,3 +30,27 @@ Expected healthy evidence from `~/.aidevops/logs/stats.log` is an hourly
 If issue #8 is stale but the log shows the skip line above and issue #17 has a
 recent `Last sweep`, the scheduler is running; the stale queue dashboard is a
 legacy/inactive-work signal rather than a plugin code defect.
+
+## Issue #26 triage evidence
+
+Issue #26 was generated from issue #8 after the legacy queue dashboard appeared
+stale. The local scheduler evidence showed the stats wrapper was still running:
+
+```text
+[stats-wrapper] Finished at 2026-06-04T17:49:19Z
+[stats] Health issue: skipping creation for Ultimate-Multisite/ultimate-ai-plugin-translations — no active PRs, assigned issues, auto-dispatch work, or workers
+[stats] Health issues: updated 15 repo(s)
+```
+
+The dashboard issue also had a fresh body marker during triage:
+
+```text
+issue #8 updated_at=2026-06-04T16:15:40Z
+has_last_refresh=true
+```
+
+Root cause: the freshness alert was based on the legacy queue dashboard's
+previous timestamp, while the stats wrapper was healthy and the repo had no
+active queue work to report. Treat this as a false-positive stale-dashboard
+alert unless `stats.log` lacks recent `[stats-wrapper] Finished` entries or the
+issue body no longer contains `last_refresh:`.


### PR DESCRIPTION
## Summary

Documented issue #26 triage evidence in DASHBOARD_FRESHNESS.md: stats-wrapper had a recent successful finish, issue #8 had a last_refresh marker, and the stale alert was a false positive from the legacy queue dashboard when this repo had no active queue work.

## Files Changed

DASHBOARD_FRESHNESS.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** git diff --check; gh api repos/Ultimate-Multisite/ultimate-ai-plugin-translations/issues/8 --jq '{updated_at, body_length: (.body|length), has_last_refresh: (.body|contains("last_refresh:"))}'

Resolves #26


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.20.12 plugin for [OpenCode](https://opencode.ai) v1.15.13 with gpt-5.5 spent 3m and 29,723 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation explaining issue triage evidence and freshness markers for dashboard monitoring processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->