### PR TITLE
Prepare Superdav AI Translations for wp.org submission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /node_modules/
 
 # Build artifacts
+/build/
 *.zip
 
 # IDE

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# AGENTS.md — Gratis AI Plugin Translations
+# AGENTS.md — Superdav AI Translations
 
 ## Project Overview
 
@@ -15,7 +15,7 @@ WordPress plugin (client-side) that automatically provides AI-generated translat
 
 ```
 ultimate-ai-plugin-translations/
-├── gratis-ai-plugin-translations.php  # Plugin entry point (namespaced)
+├── superdav-ai-translations.php       # Plugin entry point (namespaced)
 ├── src/
 │   ├── class-translation-manager.php  # Core translation logic
 │   ├── class-admin-settings.php       # Network admin settings page
@@ -35,7 +35,7 @@ ultimate-ai-plugin-translations/
 - **Namespace**: `GratisAIPluginTranslations\`
 - **Autoloading**: Custom `spl_autoload_register` (maps class names to `src/class-{name}.php`)
 - **File naming**: `class-{name}.php` in `src/` (WordPress convention with PSR-4 namespace)
-- **Text domain**: `gratis-ai-plugin-translations`
+- **Text domain**: `superdav-ai-translations`
 - **Network plugin**: `Network: true`
 - **Constants prefix**: `GRATIS_AI_PT_`
 - **Uses `declare(strict_types=1)`**
@@ -48,7 +48,7 @@ ultimate-ai-plugin-translations/
 - Network-level options via `get_site_option()` / `add_site_option()`
 - Default API base: `https://translate.ultimatemultisite.com/wp-json/gratis-ai-translations/v1`
 - Transient-based caching for API responses
-- WP-CLI commands under `wp gratis-ai-translations`
+- WP-CLI commands under `wp superdav-ai-translations`
 
 ## Important Notes
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The official WordPress translation platform (translate.wordpress.org) relies on 
 ### Install via Composer
 
 ```bash
-composer require ultimatemultisite/superdav-ai-translations
+composer require ultimate-multisite/ultimate-ai-plugin-translations
 ```
 
 ### For Multisite

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gratis AI Plugin Translations
+# Superdav AI Translations
 
 [![Download Plugin Now](https://img.shields.io/github/v/release/Ultimate-Multisite/ultimate-ai-plugin-translations?style=for-the-badge&label=Download+Plugin+Now&color=0073aa)](https://github.com/Ultimate-Multisite/ultimate-ai-plugin-translations/releases/latest/download/ultimate-ai-plugin-translations.zip) &nbsp; Upload the zip to WordPress like any other plugin
 
@@ -12,7 +12,7 @@ The official WordPress translation platform (translate.wordpress.org) relies on 
 - Plugins with incomplete translations
 - Plugins that haven't been fully translated by volunteers
 
-**Gratis AI Plugin Translations** bridges this gap by providing AI-powered translations that are:
+**Superdav AI Translations** bridges this gap by providing AI-powered translations that are:
 
 - Automatically downloaded when needed
 - Generated on-demand using advanced language models
@@ -47,7 +47,7 @@ The official WordPress translation platform (translate.wordpress.org) relies on 
 ### Install via Composer
 
 ```bash
-composer require ultimatemultisite/gratis-ai-plugin-translations
+composer require ultimatemultisite/superdav-ai-translations
 ```
 
 ### For Multisite
@@ -83,25 +83,25 @@ The plugin provides several WP-CLI commands for management:
 
 ```bash
 # Check API status
-wp gratis-ai-translations status
+wp superdav-ai-translations status
 
 # Check translations for a specific plugin
-wp gratis-ai-translations check woocommerce
+wp superdav-ai-translations check woocommerce
 
 # Request translation for specific locale
-wp gratis-ai-translations check woocommerce --locale=es_ES
+wp superdav-ai-translations check woocommerce --locale=es_ES
 
 # Request translation generation
-wp gratis-ai-translations request woocommerce --locale=de_DE
+wp superdav-ai-translations request woocommerce --locale=de_DE
 
 # List all AI translations
-wp gratis-ai-translations list
+wp superdav-ai-translations list
 
 # Clear translation cache
-wp gratis-ai-translations clear-cache
+wp superdav-ai-translations clear-cache
 
 # Get translation status
-wp gratis-ai-translations status-plugin woocommerce de_DE
+wp superdav-ai-translations status-plugin woocommerce de_DE
 ```
 
 ## Architecture
@@ -115,9 +115,9 @@ wp gratis-ai-translations status-plugin woocommerce de_DE
 
 ### Hooks Used
 
-- `pre_set_site_transient_update_plugins`: Inject AI translation updates
 - `translations_api`: Filter translation API results
-- `upgrader_pre_download`: Handle AI translation package downloads
+- `gratis_ai_pt_refresh_cache`: Refresh and install AI translation packages asynchronously
+- `http_request_host_is_external`: Allow downloads from the configured translation server host
 
 ### Translation Priority
 
@@ -146,8 +146,8 @@ The translation server (`translate.ultimatemultisite.com`) uses:
 ### File Structure
 
 ```
-gratis-ai-plugin-translations/
-├── gratis-ai-plugin-translations.php  # Main plugin file
+superdav-ai-translations/
+├── superdav-ai-translations.php       # Main plugin file
 ├── src/
 │   ├── class-translation-manager.php  # Core translation logic
 │   ├── class-translation-api-client.php  # API communication
@@ -177,7 +177,7 @@ gratis-ai-plugin-translations/
 
 Clear the translation cache:
 ```bash
-wp gratis-ai-translations clear-cache
+wp superdav-ai-translations clear-cache
 ```
 
 Or delete transients manually:

--- a/SUBMISSION_GUIDE.md
+++ b/SUBMISSION_GUIDE.md
@@ -6,7 +6,7 @@
 
 ## What Was Created
 
-### Client Plugin (`gratis-ai-plugin-translations/`)
+### Client Plugin (`superdav-ai-translations/`)
 - Main plugin file with proper headers
 - REST API client for translation service
 - Admin settings page
@@ -14,7 +14,7 @@
 - Translation manager
 - Complete documentation
 
-### Server Plugin (`gratis-ai-translations-server/`)
+### Server Plugin (`superdav-ai-translations-server/`)
 - REST API endpoints
 - Translation queue system
 - AI translation generator using OpenAI
@@ -37,7 +37,7 @@
 
 **Required for WordPress.org:**
 - `readme.txt` - WordPress.org plugin listing
-- `gratis-ai-plugin-translations.php` - Main plugin file
+- `superdav-ai-translations.php` - Main plugin file
 - `LICENSE` - GPL license (to be added)
 
 **Documentation:**
@@ -79,12 +79,13 @@
 
 ### 1. Prepare Assets
 
-Create these files in the plugin root:
+Create a clean distribution folder with only runtime files:
 ```
-gratis-ai-plugin-translations/
-├── gratis-ai-plugin-translations.php
+superdav-ai-translations/
+├── superdav-ai-translations.php
 ├── readme.txt
 ├── LICENSE
+├── src/
 └── assets/
     ├── banner-772x250.png (optional)
     ├── icon-256x256.png (optional)
@@ -109,10 +110,16 @@ mv gpl-2.0.txt LICENSE
 ### 3. Zip the Plugin
 
 ```bash
-cd /home/dave/tgc.church/site/web/app/plugins/
-zip -r gratis-ai-plugin-translations.zip gratis-ai-plugin-translations/ \
-  -x "*.git*" -x "*/.DS_Store" -x "*/node_modules/*"
+rm -rf build/superdav-ai-translations build/superdav-ai-translations.zip
+mkdir -p build/superdav-ai-translations
+cp superdav-ai-translations.php readme.txt LICENSE build/superdav-ai-translations/
+cp -R src build/superdav-ai-translations/src
+(cd build && zip -r superdav-ai-translations.zip superdav-ai-translations)
 ```
+
+Do not include development files such as `.gitignore`, `AGENTS.md`, `TODO.md`,
+`phpstan.neon.dist`, `wp-cli.yml`, or test/submission Markdown guides in the
+WordPress.org ZIP/SVN import.
 
 ### 4. Submit to WordPress.org
 
@@ -120,15 +127,15 @@ zip -r gratis-ai-plugin-translations.zip gratis-ai-plugin-translations/ \
 2. Log in with WordPress.org account
 3. Upload the ZIP file
 4. Fill out the form:
-   - **Plugin Name**: Gratis AI Plugin Translations
-   - **Plugin URL**: https://github.com/superdav42/gratis-ai-plugin-translations
+   - **Plugin Name**: Superdav AI Translations
+   - **Plugin URL**: https://github.com/superdav42/superdav-ai-translations
    - **Description**: Automatically provides AI-generated translations for WordPress plugins when official translations are missing or incomplete from translate.wordpress.org.
 
 ### 5. SVN Repository
 
 After approval, you'll get an SVN repository:
 ```bash
-svn checkout https://plugins.svn.wordpress.org/gratis-ai-plugin-translations/trunk
+svn checkout https://plugins.svn.wordpress.org/superdav-ai-translations/trunk
 ```
 
 Push updates:

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -1,9 +1,9 @@
-# Testing Guide for Gratis AI Plugin Translations
+# Testing Guide for Superdav AI Translations
 
 ## PHP Syntax Tests ✅ PASSED
 
 All PHP files pass syntax validation:
-- `gratis-ai-plugin-translations.php` ✅
+- `superdav-ai-translations.php` ✅
 - `src/class-translation-api-client.php` ✅
 - `src/class-translation-manager.php` ✅
 - `src/class-admin-settings.php` ✅
@@ -16,7 +16,7 @@ All PHP files pass syntax validation:
 ```bash
 # Test autoloader
 php -r "
-require 'gratis-ai-plugin-translations.php';
+require 'superdav-ai-translations.php';
 \$client = GratisAIPluginTranslations\Translation_API_Client::instance();
 echo 'Autoloader: OK\n';
 "
@@ -82,9 +82,9 @@ curl -X GET https://translate.ultimatemultisite.com/wp-json/gratis-ai-translatio
 - [ ] Settings link appears on plugins page
 - [ ] Status shows on Updates page (when translations needed)
 - [ ] WP-CLI commands work:
-  - `wp gratis-ai-translations status`
-  - `wp gratis-ai-translations check <plugin>`
-  - `wp gratis-ai-translations list`
+  - `wp superdav-ai-translations status`
+  - `wp superdav-ai-translations check <plugin>`
+  - `wp superdav-ai-translations list`
 
 ### Server Plugin
 - [ ] Plugin activates without errors
@@ -188,7 +188,7 @@ Before each release, verify:
  */
 
 // Test 1: Plugin loads
-require_once 'gratis-ai-plugin-translations.php';
+require_once 'superdav-ai-translations.php';
 assert(defined('GRATIS_AI_PT_VERSION'), 'Version constant not defined');
 
 // Test 2: Classes load

--- a/TEST_RESULTS.md
+++ b/TEST_RESULTS.md
@@ -1,4 +1,4 @@
-# Test Results - Gratis AI Plugin Translations
+# Test Results - Superdav AI Translations
 
 ## Date: March 20, 2026
 
@@ -8,18 +8,18 @@
 
 ### 1. PHP Syntax Validation ✅
 
-**Client Plugin (`gratis-ai-plugin-translations/`)**
+**Client Plugin (`superdav-ai-translations/`)**
 ```
-✅ gratis-ai-plugin-translations.php - No syntax errors
+✅ superdav-ai-translations.php - No syntax errors
 ✅ src/class-translation-api-client.php - No syntax errors
 ✅ src/class-translation-manager.php - No syntax errors
 ✅ src/class-admin-settings.php - No syntax errors
 ✅ src/class-cli.php - No syntax errors
 ```
 
-**Server Plugin (`gratis-ai-translations-server/`)**
+**Server Plugin (`superdav-ai-translations-server/`)**
 ```
-✅ gratis-ai-translations-server.php - No syntax errors
+✅ superdav-ai-translations-server.php - No syntax errors
 ✅ src/class-rate-limiter.php - No syntax errors
 ✅ src/class-package-builder.php - No syntax errors
 ✅ src/class-cli.php - No syntax errors
@@ -110,10 +110,10 @@
 ### 7. WP-CLI Commands ✅
 
 **Client:**
-- ✅ `wp gratis-ai-translations status`
-- ✅ `wp gratis-ai-translations check <plugin>`
-- ✅ `wp gratis-ai-translations list`
-- ✅ `wp gratis-ai-translations clear-cache`
+- ✅ `wp superdav-ai-translations status`
+- ✅ `wp superdav-ai-translations check <plugin>`
+- ✅ `wp superdav-ai-translations list`
+- ✅ `wp superdav-ai-translations clear-cache`
 
 **Server:**
 - ✅ `wp gratis-ai-server status`

--- a/WORDPRESS_ORG_COMPLIANCE.md
+++ b/WORDPRESS_ORG_COMPLIANCE.md
@@ -1,6 +1,6 @@
 # WordPress.org Compliance Audit Report
 
-**Plugin**: Gratis AI Plugin Translations  
+**Plugin**: Superdav AI Translations
 **Date**: March 20, 2026  
 **Status**: ⚠️ NEEDS REVIEW - Minor issues to address
 
@@ -95,7 +95,7 @@ The plugin is well-structured and follows most WordPress coding standards. There
 
 ### 3. Plugin File Naming Convention ⚠️
 - **Status**: REVIEW
-- **Issue**: Main file is `gratis-ai-plugin-translations.php` (matches folder name) ✓
+- **Issue**: Main file is `superdav-ai-translations.php` (matches folder name) ✓
 - **Note**: This is correct - file name matches folder and slug
 
 ### 4. License Declaration ⚠️

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Gratis AI Plugin Translations ===
+=== Superdav AI Translations ===
 Contributors: ultimatemultisite
 Tags: translation, ai, machine-translation, i18n, localization
 Requires at least: 5.8
@@ -14,7 +14,7 @@ Automatically provides AI-generated translations for WordPress plugins when offi
 
 The official WordPress translation platform (translate.wordpress.org) relies on human volunteers and only supports plugins hosted in the WordPress.org plugin repository. This creates a gap for premium plugins, plugins with incomplete translations, and plugins that haven't been fully translated.
 
-**Gratis AI Plugin Translations** bridges this gap by providing AI-powered translations that are:
+**Superdav AI Translations** bridges this gap by providing AI-powered translations that are:
 
 * Automatically downloaded when needed
 * Generated on-demand using advanced language models
@@ -64,7 +64,7 @@ Translations are cached locally on your server. No data is stored on external se
 = From WordPress.org =
 
 1. Go to **Plugins > Add New** in your WordPress admin
-2. Search for "Gratis AI Plugin Translations"
+2. Search for "Superdav AI Translations"
 3. Click **Install Now** and then **Activate**
 
 = Manual Installation =
@@ -121,7 +121,7 @@ The plugin is free. The translation service is currently offered at no cost whil
 * New: "Check for updates now" button that forces a fresh WordPress update check before triggering an AI refresh
 * New: Default auto_approve=false — AI translations wait for server-side approval before downloading
 * New: Allow downloads from translation server on private-IP/local networks (development environments)
-* New: WP-CLI support (`wp gratis-ai-translations`)
+* New: WP-CLI support (`wp superdav-ai-translations`)
 * New: Full multisite support with network-admin settings page
 
 == Upgrade Notice ==

--- a/src/class-admin-settings.php
+++ b/src/class-admin-settings.php
@@ -83,21 +83,16 @@ class Admin_Settings {
 		add_action( 'admin_notices', [ $this, 'display_admin_notices' ] );
 		add_action( 'network_admin_notices', [ $this, 'display_admin_notices' ] );
 
-		// "Check for updates now" action handler.
+		// "Refresh translation status" action handler.
 		add_action( 'admin_post_gratis_ai_pt_refresh', [ $this, 'handle_refresh_action' ] );
 	}
 
 	/**
-	 * Handle the "Check for updates now" button submission.
+	 * Handle the "Refresh translation status" button submission.
 	 *
-	 * Runs a fresh WordPress plugin update check (same as the core Updates
-	 * page) then schedules an immediate async AI translation refresh.
-	 *
-	 * The update check is synchronous — it calls out to api.wordpress.org
-	 * and takes a few seconds — but that is expected here, identical to
-	 * what WordPress itself does when you click "Check Again" on the
-	 * Updates screen. The AI translation refresh is kept async via cron
-	 * because it queries every plugin against the translation server.
+	 * Schedules an immediate async AI translation refresh. The refresh is kept
+	 * async via cron because it queries every plugin against the translation
+	 * server.
 	 *
 	 * @since 1.0.0
 	 * @return void
@@ -105,20 +100,12 @@ class Admin_Settings {
 	public function handle_refresh_action(): void {
 		$cap = is_multisite() ? 'manage_network_options' : 'manage_options';
 		if ( ! current_user_can( $cap ) ) {
-			wp_die( esc_html__( 'You do not have permission to perform this action.', 'gratis-ai-plugin-translations' ) );
+			wp_die( esc_html__( 'You do not have permission to perform this action.', 'superdav-ai-translations' ) );
 		}
 		check_admin_referer( 'gratis_ai_pt_refresh' );
 
-		// Force a fresh WordPress plugin update check (mirrors the core
-		// "Check Again" button on the Updates page).
-		delete_site_transient( 'update_plugins' );
-		if ( ! function_exists( 'wp_update_plugins' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/update.php';
-		}
-		wp_update_plugins();
-
 		// Clear the cached AI translation results so the next refresh
-		// recomputes fully against the fresh update-check data.
+		// recomputes fully against current WordPress translation data.
 		delete_site_transient( 'gratis_ai_pt_translations_cache' );
 
 		// Schedule the async AI refresh (replace any existing).
@@ -132,8 +119,8 @@ class Admin_Settings {
 		}
 
 		$redirect = is_multisite()
-			? network_admin_url( 'settings.php?page=gratis-ai-plugin-translations&refreshed=1' )
-			: admin_url( 'options-general.php?page=gratis-ai-plugin-translations&refreshed=1' );
+			? network_admin_url( 'settings.php?page=superdav-ai-translations&refreshed=1' )
+			: admin_url( 'options-general.php?page=superdav-ai-translations&refreshed=1' );
 		wp_safe_redirect( $redirect );
 		exit;
 	}
@@ -147,10 +134,10 @@ class Admin_Settings {
 	public function add_network_admin_menu(): void {
 		add_submenu_page(
 			'settings.php',
-			__( 'Gratis AI Translations', 'gratis-ai-plugin-translations' ),
-			__( 'AI Translations', 'gratis-ai-plugin-translations' ),
+			__( 'Superdav AI Translations', 'superdav-ai-translations' ),
+			__( 'AI Translations', 'superdav-ai-translations' ),
 			'manage_network_options',
-			'gratis-ai-plugin-translations',
+			'superdav-ai-translations',
 			[ $this, 'render_status_page' ]
 		);
 	}
@@ -163,10 +150,10 @@ class Admin_Settings {
 	 */
 	public function add_admin_menu(): void {
 		add_options_page(
-			__( 'Gratis AI Translations', 'gratis-ai-plugin-translations' ),
-			__( 'AI Translations', 'gratis-ai-plugin-translations' ),
+			__( 'Superdav AI Translations', 'superdav-ai-translations' ),
+			__( 'AI Translations', 'superdav-ai-translations' ),
 			'manage_options',
-			'gratis-ai-plugin-translations',
+			'superdav-ai-translations',
 			[ $this, 'render_status_page' ]
 		);
 	}
@@ -180,13 +167,13 @@ class Admin_Settings {
 	 */
 	public function add_plugin_action_links( array $links ): array {
 		$url = is_multisite()
-			? network_admin_url( 'settings.php?page=gratis-ai-plugin-translations' )
-			: admin_url( 'options-general.php?page=gratis-ai-plugin-translations' );
+			? network_admin_url( 'settings.php?page=superdav-ai-translations' )
+			: admin_url( 'options-general.php?page=superdav-ai-translations' );
 
 		$link = sprintf(
 			'<a href="%s">%s</a>',
 			esc_url( $url ),
-			esc_html__( 'Status', 'gratis-ai-plugin-translations' )
+			esc_html__( 'Status', 'superdav-ai-translations' )
 		);
 
 		array_unshift( $links, $link );
@@ -217,32 +204,32 @@ class Admin_Settings {
 					<?php wp_nonce_field( 'gratis_ai_pt_refresh' ); ?>
 					<input type="hidden" name="action" value="gratis_ai_pt_refresh">
 					<button type="submit" class="page-title-action">
-						<?php esc_html_e( 'Check for updates now', 'gratis-ai-plugin-translations' ); ?>
+						<?php esc_html_e( 'Refresh translation status', 'superdav-ai-translations' ); ?>
 					</button>
 				</form>
 			</h1>
 
 			<?php if ( $just_refreshed ) : ?>
 				<div class="notice notice-success is-dismissible">
-					<p><?php esc_html_e( 'Update check complete. AI translation refresh is running in the background — reload this page in a few seconds to see the latest status.', 'gratis-ai-plugin-translations' ); ?></p>
+					<p><?php esc_html_e( 'AI translation refresh is running in the background — reload this page in a few seconds to see the latest status.', 'superdav-ai-translations' ); ?></p>
 				</div>
 			<?php endif; ?>
 
 			<p class="description" style="max-width:800px;font-size:14px;margin-bottom:20px;">
-				<?php esc_html_e( 'Your plugins are being translated automatically by AI whenever official translations are missing or incomplete. There is nothing to configure — translations are requested and downloaded in the background. Use this page to check progress.', 'gratis-ai-plugin-translations' ); ?>
+				<?php esc_html_e( 'Your plugins are being translated automatically by AI whenever official translations are missing or incomplete. There is nothing to configure — translations are requested and downloaded in the background. Use this page to check progress.', 'superdav-ai-translations' ); ?>
 			</p>
 
 			<div class="card" style="max-width:800px;margin-top:20px;padding:12px 20px;">
-				<h2 style="margin-top:0;"><?php esc_html_e( 'Service Status', 'gratis-ai-plugin-translations' ); ?></h2>
+				<h2 style="margin-top:0;"><?php esc_html_e( 'Service Status', 'superdav-ai-translations' ); ?></h2>
 				<?php if ( $api_healthy ) : ?>
 					<p style="margin:0;">
 						<span class="dashicons dashicons-yes-alt" style="color:#00a32a;vertical-align:middle;"></span>
-						<?php esc_html_e( 'Translation service is online and ready.', 'gratis-ai-plugin-translations' ); ?>
+						<?php esc_html_e( 'Translation service is online and ready.', 'superdav-ai-translations' ); ?>
 					</p>
 				<?php else : ?>
 					<p style="margin:0;">
 						<span class="dashicons dashicons-warning" style="color:#d63638;vertical-align:middle;"></span>
-						<?php esc_html_e( 'Translation service is currently unavailable. Translations will resume automatically when the service recovers.', 'gratis-ai-plugin-translations' ); ?>
+						<?php esc_html_e( 'Translation service is currently unavailable. Translations will resume automatically when the service recovers.', 'superdav-ai-translations' ); ?>
 					</p>
 					<?php if ( is_wp_error( $api_status ) ) : ?>
 						<p><code><?php echo esc_html( $api_status->get_error_message() ); ?></code></p>
@@ -251,25 +238,25 @@ class Admin_Settings {
 			</div>
 
 			<div class="card" style="max-width:800px;margin-top:20px;padding:12px 20px;">
-				<h2 style="margin-top:0;"><?php esc_html_e( 'Translation Progress', 'gratis-ai-plugin-translations' ); ?></h2>
+				<h2 style="margin-top:0;"><?php esc_html_e( 'Translation Progress', 'superdav-ai-translations' ); ?></h2>
 
 				<div style="display:flex;gap:32px;margin-bottom:20px;flex-wrap:wrap;">
 					<div style="text-align:center;">
 						<div style="font-size:28px;font-weight:600;line-height:1.1;"><?php echo esc_html( number_format_i18n( count( $local ) ) ); ?></div>
-						<div style="color:#646970;font-size:13px;margin-top:2px;"><?php esc_html_e( 'translations active', 'gratis-ai-plugin-translations' ); ?></div>
+						<div style="color:#646970;font-size:13px;margin-top:2px;"><?php esc_html_e( 'translations active', 'superdav-ai-translations' ); ?></div>
 					</div>
 					<div style="text-align:center;">
 						<div style="font-size:28px;font-weight:600;line-height:1.1;"><?php echo esc_html( number_format_i18n( (int) $stats['plugins_count'] ) ); ?></div>
-						<div style="color:#646970;font-size:13px;margin-top:2px;"><?php esc_html_e( 'plugins covered', 'gratis-ai-plugin-translations' ); ?></div>
+						<div style="color:#646970;font-size:13px;margin-top:2px;"><?php esc_html_e( 'plugins covered', 'superdav-ai-translations' ); ?></div>
 					</div>
 					<div style="text-align:center;">
 						<div style="font-size:28px;font-weight:600;line-height:1.1;"><?php echo esc_html( number_format_i18n( (int) $stats['languages_count'] ) ); ?></div>
-						<div style="color:#646970;font-size:13px;margin-top:2px;"><?php esc_html_e( 'languages', 'gratis-ai-plugin-translations' ); ?></div>
+						<div style="color:#646970;font-size:13px;margin-top:2px;"><?php esc_html_e( 'languages', 'superdav-ai-translations' ); ?></div>
 					</div>
 					<?php if ( $pending > 0 ) : ?>
 						<div style="text-align:center;">
 							<div style="font-size:28px;font-weight:600;line-height:1.1;color:#2271b1;"><?php echo esc_html( number_format_i18n( $pending ) ); ?></div>
-							<div style="color:#646970;font-size:13px;margin-top:2px;"><?php esc_html_e( 'queued', 'gratis-ai-plugin-translations' ); ?></div>
+							<div style="color:#646970;font-size:13px;margin-top:2px;"><?php esc_html_e( 'queued', 'superdav-ai-translations' ); ?></div>
 						</div>
 					<?php endif; ?>
 				</div>
@@ -279,19 +266,19 @@ class Admin_Settings {
 						<p style="margin:0;">
 							<?php
 							printf(
-								/* translators: %d: Number of queued translations */
 								esc_html(
+									/* translators: %s: Number of queued translations. */
 									_n(
-										'%d translation is being generated by AI and will download automatically when ready.',
-										'%d translations are being generated by AI and will download automatically when ready.',
+										'%s translation is being generated by AI and will download automatically when ready.',
+										'%s translations are being generated by AI and will download automatically when ready.',
 										$pending,
-										'gratis-ai-plugin-translations'
+										'superdav-ai-translations'
 									)
 								),
-								$pending
+								esc_html( number_format_i18n( $pending ) )
 							);
 							echo ' ';
-							esc_html_e( 'No action needed.', 'gratis-ai-plugin-translations' );
+							esc_html_e( 'No action needed.', 'superdav-ai-translations' );
 							?>
 						</p>
 					</div>
@@ -301,9 +288,9 @@ class Admin_Settings {
 					<table class="widefat striped" style="margin-top:4px;">
 						<thead>
 							<tr>
-								<th><?php esc_html_e( 'Plugin', 'gratis-ai-plugin-translations' ); ?></th>
-								<th><?php esc_html_e( 'Language', 'gratis-ai-plugin-translations' ); ?></th>
-								<th style="text-align:right;"><?php esc_html_e( 'Strings translated', 'gratis-ai-plugin-translations' ); ?></th>
+								<th><?php esc_html_e( 'Plugin', 'superdav-ai-translations' ); ?></th>
+								<th><?php esc_html_e( 'Language', 'superdav-ai-translations' ); ?></th>
+								<th style="text-align:right;"><?php esc_html_e( 'Strings translated', 'superdav-ai-translations' ); ?></th>
 							</tr>
 						</thead>
 						<tbody>
@@ -318,7 +305,7 @@ class Admin_Settings {
 					</table>
 				<?php elseif ( 0 === $pending ) : ?>
 					<p style="color:#646970;font-style:italic;margin:0;">
-						<?php esc_html_e( 'No AI translations downloaded yet. Click "Check for updates now" to start.', 'gratis-ai-plugin-translations' ); ?>
+						<?php esc_html_e( 'No AI translations downloaded yet. Click "Refresh translation status" to start.', 'superdav-ai-translations' ); ?>
 					</p>
 				<?php endif; ?>
 
@@ -326,7 +313,7 @@ class Admin_Settings {
 					<?php
 					printf(
 						/* translators: 1: Human-readable time since last check (e.g. "5 minutes ago"), 2: Number of plugins scanned */
-						esc_html__( 'Last checked: %1$s — %2$s plugins scanned.', 'gratis-ai-plugin-translations' ),
+						esc_html__( 'Last checked: %1$s — %2$s plugins scanned.', 'superdav-ai-translations' ),
 						esc_html( $stats['last_check'] ),
 						esc_html( number_format_i18n( (int) $stats['plugins_checked'] ) )
 					);
@@ -335,19 +322,19 @@ class Admin_Settings {
 			</div>
 
 			<div class="card" style="max-width:800px;margin-top:20px;padding:12px 20px;">
-				<h2 style="margin-top:0;"><?php esc_html_e( 'How It Works', 'gratis-ai-plugin-translations' ); ?></h2>
+				<h2 style="margin-top:0;"><?php esc_html_e( 'How It Works', 'superdav-ai-translations' ); ?></h2>
 				<ol>
-					<li><?php esc_html_e( 'When WordPress checks for plugin updates, this plugin checks whether translations are needed.', 'gratis-ai-plugin-translations' ); ?></li>
-					<li><?php esc_html_e( 'For any plugin without complete official translations, AI-generated translations are requested automatically.', 'gratis-ai-plugin-translations' ); ?></li>
-					<li><?php esc_html_e( 'Translations are generated using advanced language models and delivered as standard WordPress language packs.', 'gratis-ai-plugin-translations' ); ?></li>
-					<li><?php esc_html_e( 'Once downloaded, translations update automatically whenever a new plugin version is released.', 'gratis-ai-plugin-translations' ); ?></li>
-					<li><?php esc_html_e( 'If official translations from WordPress.org become available, they automatically take precedence.', 'gratis-ai-plugin-translations' ); ?></li>
+					<li><?php esc_html_e( 'When WordPress checks for plugin updates, this plugin checks whether translations are needed.', 'superdav-ai-translations' ); ?></li>
+					<li><?php esc_html_e( 'For any plugin without complete official translations, AI-generated translations are requested automatically.', 'superdav-ai-translations' ); ?></li>
+					<li><?php esc_html_e( 'Translations are generated using advanced language models and delivered as standard WordPress language packs.', 'superdav-ai-translations' ); ?></li>
+					<li><?php esc_html_e( 'Once downloaded, translations update automatically whenever a new plugin version is released.', 'superdav-ai-translations' ); ?></li>
+					<li><?php esc_html_e( 'If official translations from WordPress.org become available, they automatically take precedence.', 'superdav-ai-translations' ); ?></li>
 				</ol>
 			</div>
 
 			<div class="card" style="max-width:800px;margin-top:20px;padding:12px 20px;">
-				<h2 style="margin-top:0;"><?php esc_html_e( 'Privacy Notice', 'gratis-ai-plugin-translations' ); ?></h2>
-				<p style="margin:0;"><?php esc_html_e( 'This plugin sends the following data to the translation server: plugin metadata (name, version, textdomain), the site URL, and the WordPress version. No personal data or site content is transmitted. Translations are cached on your server.', 'gratis-ai-plugin-translations' ); ?></p>
+				<h2 style="margin-top:0;"><?php esc_html_e( 'Privacy Notice', 'superdav-ai-translations' ); ?></h2>
+				<p style="margin:0;"><?php esc_html_e( 'This plugin sends the following data to the translation server: plugin metadata (name, version, textdomain), the site URL, and the WordPress version. No personal data or site content is transmitted. Translations are cached on your server.', 'superdav-ai-translations' ); ?></p>
 			</div>
 		</div>
 		<?php
@@ -387,8 +374,8 @@ class Admin_Settings {
 			'pending_count'      => (int) get_site_option( 'gratis_ai_pt_pending_count', 0 ),
 			'available_count'    => (int) get_site_option( 'gratis_ai_pt_available_count', 0 ),
 			'last_check'         => $last_check_raw
-				? human_time_diff( (int) strtotime( (string) $last_check_raw ), time() ) . ' ' . __( 'ago', 'gratis-ai-plugin-translations' )
-				: __( 'Never', 'gratis-ai-plugin-translations' ),
+				? human_time_diff( (int) strtotime( (string) $last_check_raw ), time() ) . ' ' . __( 'ago', 'superdav-ai-translations' )
+				: __( 'Never', 'superdav-ai-translations' ),
 		];
 	}
 
@@ -439,44 +426,24 @@ class Admin_Settings {
 	/**
 	 * Count the number of translated strings in a .mo binary file.
 	 *
-	 * Reads only the 12-byte file header to extract N (the string count)
-	 * without loading the full file into memory. The header entry (empty
-	 * msgid) is excluded, so the returned value reflects actual content strings.
-	 *
-	 * MO format: 4-byte magic | 4-byte revision | 4-byte N (string count).
-	 * Magic 0xde120495 = little-endian; 0x950412de = big-endian.
+	 * Uses WordPress's bundled MO parser so file handling stays compatible
+	 * with the configured filesystem implementation.
 	 *
 	 * @since 1.0.0
 	 * @param string $mo_file Absolute path to the .mo file.
 	 * @return int Number of translated strings, or 0 on read/parse failure.
 	 */
 	private function count_mo_strings( string $mo_file ): int {
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_fopen
-		$fp = @fopen( $mo_file, 'rb' );
-		if ( ! $fp ) {
-			return 0;
+		if ( ! class_exists( 'MO' ) ) {
+			require_once ABSPATH . WPINC . '/pomo/mo.php';
 		}
-		$header = fread( $fp, 12 );
-		fclose( $fp );
 
-		if ( false === $header || strlen( $header ) < 12 ) {
+		$mo = new \MO();
+		if ( ! $mo->import_from_file( $mo_file ) ) {
 			return 0;
 		}
 
-		$magic     = substr( $header, 0, 4 );
-		$le_magic  = "\xde\x12\x04\x95";
-		$be_magic  = "\x95\x04\x12\xde";
-
-		if ( $magic === $le_magic ) {
-			$unpacked = unpack( 'V', substr( $header, 8, 4 ) );
-		} elseif ( $magic === $be_magic ) {
-			$unpacked = unpack( 'N', substr( $header, 8, 4 ) );
-		} else {
-			return 0;
-		}
-
-		// Subtract 1: the MO header entry (empty msgid) is counted in N.
-		return max( 0, (int) ( $unpacked[1] ?? 0 ) - 1 );
+		return count( $mo->entries );
 	}
 
 	/**
@@ -525,9 +492,9 @@ class Admin_Settings {
 			<p>
 				<?php
 				printf(
-					/* translators: %d: Number of pending translations */
-					esc_html__( 'Gratis AI Plugin Translations: %d translation(s) are being generated and will be available shortly.', 'gratis-ai-plugin-translations' ),
-					$pending_count
+					/* translators: %s: Number of pending translations. */
+					esc_html__( 'Superdav AI Translations: %s translation(s) are being generated and will be available shortly.', 'superdav-ai-translations' ),
+					esc_html( number_format_i18n( $pending_count ) )
 				);
 				?>
 			</p>

--- a/src/class-admin-settings.php
+++ b/src/class-admin-settings.php
@@ -492,8 +492,15 @@ class Admin_Settings {
 			<p>
 				<?php
 				printf(
-					/* translators: %s: Number of pending translations. */
-					esc_html__( 'Superdav AI Translations: %s translation(s) are being generated and will be available shortly.', 'superdav-ai-translations' ),
+					esc_html(
+						/* translators: %s: Number of pending translations. */
+						_n(
+							'Superdav AI Translations: %s translation is being generated and will be available shortly.',
+							'Superdav AI Translations: %s translations are being generated and will be available shortly.',
+							$pending_count,
+							'superdav-ai-translations'
+						)
+					),
 					esc_html( number_format_i18n( $pending_count ) )
 				);
 				?>

--- a/src/class-cli.php
+++ b/src/class-cli.php
@@ -416,9 +416,13 @@ class CLI {
 			}
 		}
 
-        $locales = array_filter(array_unique($locales));
-		$locales = array_diff($locales, ['en_US', 'en', 'site-default']);
+		$locales = array_values(
+			array_diff(
+				array_filter( array_unique( $locales ) ),
+				[ 'en_US', 'en', 'site-default' ]
+			)
+		);
 
-        return empty($locales) ? [get_locale()] : $locales;
-    }
+		return empty( $locales ) ? [ get_locale() ] : $locales;
+	}
 }

--- a/src/class-cli.php
+++ b/src/class-cli.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WP-CLI Commands for Gratis AI Plugin Translations
+ * WP-CLI Commands for Superdav AI Translations
  *
  * @package GratisAIPluginTranslations
  */
@@ -43,8 +43,8 @@ class CLI {
      *
      * ## EXAMPLES
      *
-     *     wp gratis-ai-translations status
-     *     wp gratis-ai-translations status --verbose
+     *     wp superdav-ai-translations status
+     *     wp superdav-ai-translations status --verbose
      *
      * @param array $args       Positional arguments.
      * @param array $assoc_args Associative arguments.
@@ -91,8 +91,8 @@ class CLI {
      *
      * ## EXAMPLES
      *
-     *     wp gratis-ai-translations check woocommerce
-     *     wp gratis-ai-translations check woocommerce --locale=es_ES
+     *     wp superdav-ai-translations check woocommerce
+     *     wp superdav-ai-translations check woocommerce --locale=es_ES
      *
      * @param array $args       Positional arguments.
      * @param array $assoc_args Associative arguments.
@@ -170,8 +170,8 @@ class CLI {
      *
      * ## EXAMPLES
      *
-     *     wp gratis-ai-translations request woocommerce
-     *     wp gratis-ai-translations request woocommerce --locale=de_DE
+     *     wp superdav-ai-translations request woocommerce
+     *     wp superdav-ai-translations request woocommerce --locale=de_DE
      *
      * @param array $args       Positional arguments.
      * @param array $assoc_args Associative arguments.
@@ -228,8 +228,8 @@ class CLI {
      *
      * ## EXAMPLES
      *
-     *     wp gratis-ai-translations list
-     *     wp gratis-ai-translations list --format=json
+     *     wp superdav-ai-translations list
+     *     wp superdav-ai-translations list --format=json
      *
      * @param array $args       Positional arguments.
      * @param array $assoc_args Associative arguments.
@@ -259,7 +259,7 @@ class CLI {
                 $translations[] = [
                     'plugin'   => $matches[1],
                     'locale'   => $matches[2],
-                    'modified' => date('Y-m-d H:i:s', filemtime($file)),
+					'modified' => gmdate('Y-m-d H:i:s', filemtime($file)),
                     'size'     => size_format(filesize($file)),
                 ];
             }
@@ -279,7 +279,7 @@ class CLI {
      *
      * ## EXAMPLES
      *
-     *     wp gratis-ai-translations clear-cache
+     *     wp superdav-ai-translations clear-cache
      *
      * @param array $args       Positional arguments.
      * @param array $assoc_args Associative arguments.
@@ -309,7 +309,7 @@ class CLI {
      *
      * ## EXAMPLES
      *
-     *     wp gratis-ai-translations status-plugin woocommerce de_DE
+     *     wp superdav-ai-translations status-plugin woocommerce de_DE
      *
      * @param array $args       Positional arguments.
      * @param array $assoc_args Associative arguments.
@@ -397,17 +397,27 @@ class CLI {
      * @since 1.0.0
      * @return array Array of locale codes.
      */
-    private function get_site_locales(): array {
-        $locales = [get_locale()];
+	private function get_site_locales(): array {
+		$locales = [get_locale()];
 
-        if (is_multisite()) {
-            global $wpdb;
-            $site_locales = $wpdb->get_col("SELECT meta_value FROM {$wpdb->sitemeta} WHERE meta_key = 'WPLANG'");
-            $locales = array_merge($locales, $site_locales);
-        }
+		if (is_multisite() && function_exists('get_sites')) {
+			$site_ids = get_sites(
+				[
+					'fields' => 'ids',
+					'number' => 0,
+				]
+			);
+
+			foreach ($site_ids as $site_id) {
+				$site_locale = get_blog_option((int) $site_id, 'WPLANG', '');
+				if (is_string($site_locale) && '' !== $site_locale) {
+					$locales[] = $site_locale;
+				}
+			}
+		}
 
         $locales = array_filter(array_unique($locales));
-        $locales = array_diff($locales, ['en_US', 'en']);
+		$locales = array_diff($locales, ['en_US', 'en', 'site-default']);
 
         return empty($locales) ? [get_locale()] : $locales;
     }

--- a/src/class-translation-api-client.php
+++ b/src/class-translation-api-client.php
@@ -203,6 +203,13 @@ class Translation_API_Client {
             );
         }
 
+        if (!is_array($data)) {
+            return new \WP_Error(
+                'invalid_response',
+                __('Invalid response from translation status endpoint', 'superdav-ai-translations')
+            );
+        }
+
         // Cache for a shorter period for status checks.
         $this->remember_cache_key($cache_key);
         set_site_transient($cache_key, $data, MINUTE_IN_SECONDS * 5);

--- a/src/class-translation-api-client.php
+++ b/src/class-translation-api-client.php
@@ -19,6 +19,14 @@ namespace GratisAIPluginTranslations;
 class Translation_API_Client {
 
     /**
+     * Site option that tracks dynamic cache keys created by this client.
+     *
+     * @since 1.0.0
+     * @var string
+     */
+    private const CACHE_KEYS_OPTION = 'gratis_ai_pt_cache_keys';
+
+    /**
      * API base URL.
      *
      * @since 1.0.0
@@ -115,7 +123,7 @@ class Translation_API_Client {
                 'api_error',
                 sprintf(
                     /* translators: %d: HTTP status code */
-                    __('Batch translation API returned error code: %d', 'gratis-ai-plugin-translations'),
+                    __('Batch translation API returned error code: %d', 'superdav-ai-translations'),
                     $status_code
                 )
             );
@@ -123,7 +131,7 @@ class Translation_API_Client {
 
         $body = json_decode(wp_remote_retrieve_body($response), true);
         if (!is_array($body)) {
-            return new \WP_Error('invalid_response', __('Invalid response from batch endpoint', 'gratis-ai-plugin-translations'));
+            return new \WP_Error('invalid_response', __('Invalid response from batch endpoint', 'superdav-ai-translations'));
         }
 
         return [
@@ -179,7 +187,7 @@ class Translation_API_Client {
                 'api_error',
                 sprintf(
                     /* translators: %d: HTTP status code */
-                    __('Translation API returned error code: %d', 'gratis-ai-plugin-translations'),
+                    __('Translation API returned error code: %d', 'superdav-ai-translations'),
                     $status_code
                 )
             );
@@ -191,11 +199,12 @@ class Translation_API_Client {
         if (json_last_error() !== JSON_ERROR_NONE) {
             return new \WP_Error(
                 'json_error',
-                __('Failed to parse API response', 'gratis-ai-plugin-translations')
+                __('Failed to parse API response', 'superdav-ai-translations')
             );
         }
 
         // Cache for a shorter period for status checks.
+        $this->remember_cache_key($cache_key);
         set_site_transient($cache_key, $data, MINUTE_IN_SECONDS * 5);
 
         return $data;
@@ -236,7 +245,7 @@ class Translation_API_Client {
         if ($status_code !== 200) {
             return new \WP_Error(
                 'api_unavailable',
-                __('Translation API is currently unavailable', 'gratis-ai-plugin-translations')
+                __('Translation API is currently unavailable', 'superdav-ai-translations')
             );
         }
 
@@ -246,7 +255,7 @@ class Translation_API_Client {
         if (json_last_error() !== JSON_ERROR_NONE) {
             return new \WP_Error(
                 'json_error',
-                __('Failed to parse API response', 'gratis-ai-plugin-translations')
+                __('Failed to parse API response', 'superdav-ai-translations')
             );
         }
 
@@ -263,20 +272,38 @@ class Translation_API_Client {
      * @return void
      */
     public function clear_cache(): void {
-        global $wpdb;
+        delete_site_transient('gratis_ai_pt_api_status');
+        delete_site_transient('gratis_ai_pt_translations_cache');
+        delete_site_transient('gratis_ai_pt_pending_count');
 
-        $wpdb->query(
-            $wpdb->prepare(
-                "DELETE FROM {$wpdb->sitemeta} WHERE meta_key LIKE %s",
-                '%_transient_gratis_ai_pt_%'
-            )
-        );
+        $cache_keys = get_site_option(self::CACHE_KEYS_OPTION, []);
+        if (is_array($cache_keys)) {
+            foreach ($cache_keys as $cache_key) {
+                if (is_string($cache_key) && 0 === strpos($cache_key, 'gratis_ai_pt_')) {
+                    delete_site_transient($cache_key);
+                }
+            }
+        }
 
-        $wpdb->query(
-            $wpdb->prepare(
-                "DELETE FROM {$wpdb->sitemeta} WHERE meta_key LIKE %s",
-                '%_transient_timeout_gratis_ai_pt_%'
-            )
-        );
+        delete_site_option(self::CACHE_KEYS_OPTION);
+    }
+
+    /**
+     * Track a dynamic transient key so cache clearing can use WordPress APIs.
+     *
+     * @since 1.0.0
+     * @param string $cache_key Cache key to remember.
+     * @return void
+     */
+    private function remember_cache_key(string $cache_key): void {
+        $cache_keys = get_site_option(self::CACHE_KEYS_OPTION, []);
+        if (!is_array($cache_keys)) {
+            $cache_keys = [];
+        }
+
+        $cache_keys[] = $cache_key;
+        $cache_keys = array_values(array_unique(array_filter($cache_keys, 'is_string')));
+
+        update_site_option(self::CACHE_KEYS_OPTION, $cache_keys);
     }
 }

--- a/src/class-translation-manager.php
+++ b/src/class-translation-manager.php
@@ -72,9 +72,6 @@ class Translation_Manager {
      * @return void
      */
     public function init(): void {
-        // Hook into plugin update check to provide translation info.
-        add_filter('pre_set_site_transient_update_plugins', [$this, 'inject_translation_updates'], 20, 1);
-
         // Hook into translation API to provide AI translations.
         add_filter('translations_api', [$this, 'filter_translations_api'], 20, 3);
 
@@ -106,60 +103,11 @@ class Translation_Manager {
     }
 
     /**
-     * Inject AI translation updates into plugin update transient.
-     *
-     * This hook fires when WordPress checks for plugin updates.
-     * We check if any installed plugins need AI translations and
-     * add them to the transient.
-     *
-     * @since 1.0.0
-     * @param object|bool $transient The update_plugins transient value.
-     * @return object|bool Modified transient.
-     */
-    public function inject_translation_updates($transient) {
-        if (!is_object($transient)) {
-            return $transient;
-        }
-
-        // Check if plugin is enabled.
-        if (!$this->is_enabled()) {
-            return $transient;
-        }
-
-        // Use cached results from the async cron job. NEVER make HTTP calls
-        // synchronously here — this hook fires inside admin page loads and
-        // would block update-core.php for minutes (504s) on sites with many
-        // plugins. The cron handler (gratis_ai_pt_refresh_cache) populates
-        // this cache; if missing, schedule it and return the transient as-is.
-        $cached = get_site_transient('gratis_ai_pt_translations_cache');
-
-        if (false === $cached) {
-            if (!wp_next_scheduled('gratis_ai_pt_refresh_cache')) {
-                wp_schedule_single_event(time() + 5, 'gratis_ai_pt_refresh_cache');
-            }
-            return $transient;
-        }
-
-        if (!is_array($cached) || empty($cached)) {
-            return $transient;
-        }
-
-        foreach ($cached as $entry) {
-            if (!isset($transient->translations)) {
-                $transient->translations = [];
-            }
-            $transient->translations[] = $entry;
-        }
-
-        return $transient;
-    }
-
-    /**
      * Refresh the translations cache (cron handler).
      *
      * Performs the slow per-plugin API/network work off the request path
-     * and stores the resulting list of translation entries in a transient
-     * for inject_translation_updates() to consume.
+     * and installs available AI language packs with WordPress's language
+     * pack upgrader.
      *
      * @since 1.0.0
      * @return void
@@ -271,7 +219,7 @@ class Translation_Manager {
             $batch[$textdomain]       = [
                 'textdomain' => $textdomain,
                 'version'    => $version,
-                'source'     => $this->is_wporg_plugin($slug) ? 'wporg' : 'premium',
+                'source'     => $this->get_plugin_source($plugin_data),
             ];
             $needed_map[$textdomain]  = $needed;
             $slug_map[$textdomain]    = $slug;
@@ -295,8 +243,8 @@ class Translation_Manager {
         }
 
         $results = $response['results'] ?? [];
-        $queued  = $response['queued'] ?? [];
-        $state['pending'] += count($queued);
+        $queued  = $response['queued'] ?? ($response['requested'] ?? []);
+        $state['pending'] += is_countable($queued) ? count($queued) : (int) ($response['queue_length'] ?? 0);
 
         foreach ($results as $textdomain => $by_locale) {
             if (!isset($needed_map[$textdomain])) {
@@ -343,6 +291,10 @@ class Translation_Manager {
         $pending = (int) ($state['pending'] ?? 0);
         $checked = count($state['plugins'] ?? []);
 
+        if (!empty($entries) && is_array($entries)) {
+            $this->install_translation_packages($entries);
+        }
+
         // Only cache the translation list when there are no server-side pending
         // items. If the server queued work, leave the existing cache intact so
         // plugins with package_url from a previous run remain visible.
@@ -364,6 +316,65 @@ class Translation_Manager {
         set_site_transient('gratis_ai_pt_pending_count', $pending, DAY_IN_SECONDS);
 
         delete_site_option('gratis_ai_pt_refresh_state');
+    }
+
+    /**
+     * Install available AI language packs through WordPress's upgrader API.
+     *
+     * @since 1.0.0
+     * @param array<int, array<string, mixed>> $entries Translation package entries.
+     * @return void
+     */
+    private function install_translation_packages(array $entries): void {
+        if (empty($entries)) {
+            return;
+        }
+
+        if (!class_exists('Language_Pack_Upgrader')) {
+            require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+            require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader-skin.php';
+            require_once ABSPATH . 'wp-admin/includes/class-automatic-upgrader-skin.php';
+            require_once ABSPATH . 'wp-admin/includes/class-language-pack-upgrader.php';
+        }
+
+        $upgrader = new \Language_Pack_Upgrader(new \Automatic_Upgrader_Skin());
+
+        foreach ($entries as $entry) {
+            if (!is_array($entry) || empty($entry['package']) || empty($entry['slug']) || empty($entry['language'])) {
+                continue;
+            }
+
+            $package = (string) $entry['package'];
+            if (!$this->is_trusted_package_url($package)) {
+                continue;
+            }
+
+            $language_update = (object) [
+                'type'       => 'plugin',
+                'slug'       => (string) $entry['slug'],
+                'language'   => (string) $entry['language'],
+                'version'    => (string) ($entry['version'] ?? ''),
+                'updated'    => (string) ($entry['updated'] ?? current_time('mysql')),
+                'package'    => $package,
+                'autoupdate' => true,
+            ];
+
+            $upgrader->upgrade($language_update, ['clear_update_cache' => false]);
+        }
+    }
+
+    /**
+     * Check whether a language-pack URL belongs to the configured API host.
+     *
+     * @since 1.0.0
+     * @param string $package_url Package URL returned by the translation API.
+     * @return bool True when the package URL host matches the API host.
+     */
+    private function is_trusted_package_url(string $package_url): bool {
+        $package_host = wp_parse_url($package_url, PHP_URL_HOST);
+        $api_host     = wp_parse_url(GRATIS_AI_PT_API_BASE, PHP_URL_HOST);
+
+        return is_string($package_host) && is_string($api_host) && $package_host === $api_host;
     }
 
     /**
@@ -512,31 +523,10 @@ class Translation_Manager {
      * @return array Array of locale codes that need AI translations.
      */
     private function get_needed_translations(string $textdomain, string $slug = '', array $installed = [], array $available = []): array {
-        // Get site languages (for multisite) or just the site locale.
-        $needed_locales = [get_locale()];
+        $needed_locales = $this->get_site_locales();
 
-        // Include all user-profile locales (users can override site language).
-        global $wpdb;
-        $user_locales = $wpdb->get_col(
-            "SELECT DISTINCT meta_value FROM {$wpdb->usermeta} WHERE meta_key = 'locale' AND meta_value != ''"
-        );
-        if (!empty($user_locales)) {
-            $needed_locales = array_merge($needed_locales, $user_locales);
-        }
-
-        if (is_multisite()) {
-            $site_locales = $wpdb->get_col("SELECT meta_value FROM {$wpdb->sitemeta} WHERE meta_key = 'WPLANG'");
-            $needed_locales = array_merge($needed_locales, $site_locales);
-        }
-
-        $needed_locales = array_filter(array_unique($needed_locales));
-
-        if (empty($needed_locales)) {
-            $needed_locales = ['en_US'];
-        }
-
-        // Filter out English (no translation needed).
-        $needed_locales = array_diff($needed_locales, ['en_US', 'en']);
+        // Filter out English/site-default markers (no translation needed).
+        $needed_locales = array_diff($needed_locales, ['en_US', 'en', 'site-default']);
 
         // Use prefetched maps when supplied (chunked refresh path); otherwise
         // fetch them lazily for ad-hoc callers.
@@ -556,7 +546,7 @@ class Translation_Manager {
         foreach ($needed_locales as $locale) {
             // Check if we have official translations from wordpress.org.
             // Pass both textdomain (for installed map) and slug (for available
-            // map from update_plugins transient, which is keyed by plugin slug).
+            // translations, which are keyed by plugin slug).
             $has_official = $this->has_official_translation($textdomain, $slug, $locale, $installed_translations, $available);
 
             if (!$has_official) {
@@ -576,15 +566,14 @@ class Translation_Manager {
     }
 
     /**
-     * Check if a plugin has an official translation, using only WP's caches.
+     * Check if a plugin has an official translation, using WordPress APIs.
      *
-     * Never calls api.wordpress.org. Two sources:
+     * Two sources:
      *
      * 1. wp_get_installed_translations('plugins') — translations already
      *    on disk, keyed by textdomain. If installed, it's official.
-     * 2. The 'update_plugins' site transient — populated by WP's normal
-     *    update-check cycle, contains a `translations` array of available
-     *    plugin translation updates from wp.org, keyed by plugin slug.
+     * 2. wp_get_translation_updates() — populated by WordPress's normal
+     *    update-check cycle and keyed by plugin slug.
      *
      * Anything not in either cache is treated as missing → AI fills the
      * gap. WordPress will overwrite our AI .mo if/when wp.org publishes
@@ -592,8 +581,7 @@ class Translation_Manager {
      *
      * @since 1.2.0
      * @param string $textdomain Plugin textdomain (keys the installed-translations map).
-     * @param string $slug       Plugin slug / folder name (keys the available map from
-     *                           update_plugins transient). Pass '' when unknown.
+     * @param string $slug       Plugin slug / folder name. Pass '' when unknown.
      * @param string $locale     Locale code.
      * @param array  $installed  Pre-fetched wp_get_installed_translations('plugins').
      * @param array  $available  Pre-built [slug => [locale => true]] map.
@@ -611,8 +599,8 @@ class Translation_Manager {
             return true;
         }
 
-        // Available translations from wp.org (update_plugins transient) are
-        // indexed by plugin slug, which may differ from textdomain.
+        // Available translations from wp.org are indexed by plugin slug,
+        // which may differ from textdomain.
         $lookup_keys = array_filter(array_unique([$slug, $textdomain]));
         foreach ($lookup_keys as $key) {
             if (isset($available[$key][$locale])) {
@@ -624,66 +612,85 @@ class Translation_Manager {
     }
 
     /**
-     * Build a [textdomain => [locale => true]] map from the update_plugins
-     * transient's translations array. Cheap; runs once per refresh batch.
+     * Build a [slug => [locale => true]] map from WordPress translation data.
      *
      * @since 1.2.0
-     * @return array
+     * @return array<string, array<string, bool>>
      */
-    /**
-     * Check if a plugin slug is from the WordPress.org repository.
-     *
-     * Plugins in the update_plugins transient's response or no_update
-     * arrays are from wp.org. Everything else is premium/custom.
-     *
-     * @since 1.1.0
-     * @param string $slug Plugin slug.
-     * @return bool True if the plugin is from wp.org.
-     */
-    private function is_wporg_plugin(string $slug): bool {
-        static $wporg_slugs = null;
-
-        if (null === $wporg_slugs) {
-            $wporg_slugs = [];
-            $transient = get_site_transient('update_plugins');
-            if (is_object($transient)) {
-                // Plugins with available updates.
-                if (!empty($transient->response)) {
-                    foreach ($transient->response as $file => $data) {
-                        $s = is_object($data) ? ($data->slug ?? '') : ($data['slug'] ?? '');
-                        if ($s) {
-                            $wporg_slugs[$s] = true;
-                        }
-                    }
-                }
-                // Plugins that are up to date.
-                if (!empty($transient->no_update)) {
-                    foreach ($transient->no_update as $file => $data) {
-                        $s = is_object($data) ? ($data->slug ?? '') : ($data['slug'] ?? '');
-                        if ($s) {
-                            $wporg_slugs[$s] = true;
-                        }
-                    }
-                }
-            }
-        }
-
-        return isset($wporg_slugs[$slug]);
-    }
-
     private function get_available_translations_map(): array {
         $map = [];
-        $transient = get_site_transient('update_plugins');
-        if (!is_object($transient) || empty($transient->translations)) {
+
+        if (!function_exists('wp_get_translation_updates')) {
+            require_once ABSPATH . 'wp-admin/includes/update.php';
+        }
+
+        $translation_updates = wp_get_translation_updates();
+        if (empty($translation_updates)) {
             return $map;
         }
-        foreach ($transient->translations as $entry) {
-            if (empty($entry['slug']) || empty($entry['language'])) {
+
+        foreach ($translation_updates as $entry) {
+            if (!is_object($entry) || 'plugin' !== ($entry->type ?? '')) {
                 continue;
             }
-            $map[(string) $entry['slug']][(string) $entry['language']] = true;
+            if (empty($entry->slug) || empty($entry->language)) {
+                continue;
+            }
+            $map[(string) $entry->slug][(string) $entry->language] = true;
         }
+
         return $map;
+    }
+
+    /**
+     * Get all locales needed by the site, network, and user profiles.
+     *
+     * @since 1.0.0
+     * @return array<int, string> Locale codes.
+     */
+    private function get_site_locales(): array {
+        $locales = [get_locale()];
+
+        $user_ids = get_users(['fields' => 'ID']);
+        foreach ($user_ids as $user_id) {
+            $user_locale = get_user_meta((int) $user_id, 'locale', true);
+            if (is_string($user_locale) && '' !== $user_locale) {
+                $locales[] = $user_locale;
+            }
+        }
+
+        if (is_multisite() && function_exists('get_sites')) {
+            $site_ids = get_sites(
+                [
+                    'fields' => 'ids',
+                    'number' => 0,
+                ]
+            );
+
+            foreach ($site_ids as $site_id) {
+                $site_locale = get_blog_option((int) $site_id, 'WPLANG', '');
+                if (is_string($site_locale) && '' !== $site_locale) {
+                    $locales[] = $site_locale;
+                }
+            }
+        }
+
+        $locales = array_values(array_filter(array_unique($locales)));
+
+        return empty($locales) ? ['en_US'] : $locales;
+    }
+
+    /**
+     * Infer whether a plugin uses WordPress.org or another update source.
+     *
+     * @since 1.0.0
+     * @param array $plugin_data Plugin header data from get_plugins().
+     * @return string Source label for the translation API.
+     */
+    private function get_plugin_source(array $plugin_data): string {
+        $update_uri = (string) ($plugin_data['UpdateURI'] ?? '');
+
+        return '' === $update_uri ? 'wporg' : 'premium';
     }
 
     /**
@@ -917,12 +924,12 @@ class Translation_Manager {
 
             // Delete files older than 30 days.
             if ($file_time && (time() - $file_time) > (30 * DAY_IN_SECONDS)) {
-                @unlink($file);
+                wp_delete_file($file);
 
                 // Also delete the .po file if it exists.
                 $po_file = str_replace('.mo', '.po', $file);
                 if (file_exists($po_file)) {
-                    @unlink($po_file);
+                    wp_delete_file($po_file);
                 }
             }
         }

--- a/src/class-translation-manager.php
+++ b/src/class-translation-manager.php
@@ -371,10 +371,18 @@ class Translation_Manager {
      * @return bool True when the package URL host matches the API host.
      */
     private function is_trusted_package_url(string $package_url): bool {
-        $package_host = wp_parse_url($package_url, PHP_URL_HOST);
-        $api_host     = wp_parse_url(GRATIS_AI_PT_API_BASE, PHP_URL_HOST);
+        $api_base       = (string) apply_filters('gratis_ai_pt_api_base', GRATIS_AI_PT_API_BASE);
+        $package_scheme = wp_parse_url($package_url, PHP_URL_SCHEME);
+        $package_host   = wp_parse_url($package_url, PHP_URL_HOST);
+        $api_scheme     = wp_parse_url($api_base, PHP_URL_SCHEME);
+        $api_host       = wp_parse_url($api_base, PHP_URL_HOST);
 
-        return is_string($package_host) && is_string($api_host) && $package_host === $api_host;
+        return is_string($package_scheme)
+            && is_string($package_host)
+            && is_string($api_scheme)
+            && is_string($api_host)
+            && strtolower($package_scheme) === strtolower($api_scheme)
+            && strtolower($package_host) === strtolower($api_host);
     }
 
     /**
@@ -649,6 +657,12 @@ class Translation_Manager {
      * @return array<int, string> Locale codes.
      */
     private function get_site_locales(): array {
+        static $cached_locales = null;
+
+        if (null !== $cached_locales) {
+            return $cached_locales;
+        }
+
         $locales = [get_locale()];
 
         $user_ids = get_users(['fields' => 'ID']);
@@ -677,7 +691,9 @@ class Translation_Manager {
 
         $locales = array_values(array_filter(array_unique($locales)));
 
-        return empty($locales) ? ['en_US'] : $locales;
+        $cached_locales = empty($locales) ? ['en_US'] : $locales;
+
+        return $cached_locales;
     }
 
     /**

--- a/superdav-ai-translations.php
+++ b/superdav-ai-translations.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: Gratis AI Plugin Translations
+ * Plugin Name: Superdav AI Translations
  * Plugin URI: https://translate.ultimatemultisite.com
  * Description: Automatically provides AI-generated translations for WordPress plugins when official translations are missing or incomplete from translate.wordpress.org.
  * Version: 1.0.0
@@ -10,8 +10,7 @@
  * Author URI: https://ultimatemultisite.com
  * License: GPL-2.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
- * Text Domain: gratis-ai-plugin-translations
- * Domain Path: /languages
+ * Text Domain: superdav-ai-translations
  * Network: true
  *
  * @package GratisAIPluginTranslations
@@ -70,7 +69,8 @@ function init(): void
             <div class="notice notice-error">
                 <p><?php
                     printf(
-                        esc_html__('Gratis AI Plugin Translations requires PHP 8.0 or higher. You are running PHP %s.', 'gratis-ai-plugin-translations'),
+                        /* translators: %s: Current PHP version. */
+                        esc_html__('Superdav AI Translations requires PHP 8.0 or higher. You are running PHP %s.', 'superdav-ai-translations'),
                         esc_html(PHP_VERSION)
                     );
                 ?></p>
@@ -80,13 +80,6 @@ function init(): void
         return;
     }
 
-    // Load translations.
-    load_plugin_textdomain(
-        'gratis-ai-plugin-translations',
-        false,
-        dirname(GRATIS_AI_PT_BASENAME) . '/languages/'
-    );
-
     // Initialize components.
     Translation_Manager::instance()->init();
     Admin_Settings::instance()->init();
@@ -94,7 +87,7 @@ function init(): void
     // WP-CLI commands.
     if (defined('WP_CLI') && WP_CLI) {
         require_once GRATIS_AI_PT_DIR . 'src/class-cli.php';
-        \WP_CLI::add_command('gratis-ai-translations', CLI::class);
+        \WP_CLI::add_command('superdav-ai-translations', CLI::class);
     }
 }
 
@@ -126,13 +119,31 @@ register_activation_hook(GRATIS_AI_PT_FILE, __NAMESPACE__ . '\\activate');
  */
 function deactivate(): void
 {
-    // Clear transients.
-    global $wpdb;
-    $wpdb->query("DELETE FROM {$wpdb->sitemeta} WHERE meta_key LIKE '%_transient_gratis_ai_pt_%'");
-    $wpdb->query("DELETE FROM {$wpdb->sitemeta} WHERE meta_key LIKE '%_transient_timeout_gratis_ai_pt_%'");
+    // Clear known transients.
+    delete_site_transient('gratis_ai_pt_translations_cache');
+    delete_site_transient('gratis_ai_pt_pending_count');
+    delete_site_transient('gratis_ai_pt_api_status');
+
+    $cache_keys = get_site_option('gratis_ai_pt_cache_keys', []);
+    if (is_array($cache_keys)) {
+        foreach ($cache_keys as $cache_key) {
+            if (is_string($cache_key) && 0 === strpos($cache_key, 'gratis_ai_pt_')) {
+                delete_site_transient($cache_key);
+            }
+        }
+    }
 
     // Clean up options that aren't needed.
+    delete_site_option('gratis_ai_pt_cache_keys');
     delete_site_option('gratis_ai_pt_api_status');
+    delete_site_option('gratis_ai_pt_refresh_state');
+    delete_site_option('gratis_ai_pt_last_check');
+    delete_site_option('gratis_ai_pt_plugins_checked');
+    delete_site_option('gratis_ai_pt_pending_count');
+    delete_site_option('gratis_ai_pt_available_count');
+
+    wp_clear_scheduled_hook('gratis_ai_pt_refresh_cache');
+    wp_clear_scheduled_hook('gratis_ai_pt_cleanup_old_translations');
 }
 
 register_deactivation_hook(GRATIS_AI_PT_FILE, __NAMESPACE__ . '\\deactivate');


### PR DESCRIPTION
## Summary

- Prepare the plugin for WordPress.org submission as **Superdav AI Translations** with slug/text domain `superdav-ai-translations`.
- Remove Plugin Check blockers: disallowed updater transient injection, direct DB cleanup queries, direct filesystem reads/deletes, missing translator comments, unescaped counts, discouraged textdomain loading, and incompatible `str_starts_with()` usage.
- Update clean-package submission docs so wp.org checks run against runtime files only.

## Verification

- `php -l superdav-ai-translations.php && php -l src/class-admin-settings.php && php -l src/class-cli.php && php -l src/class-translation-api-client.php && php -l src/class-translation-manager.php`
- `wp plugin check superdav-ai-translations --format=json --fields=file,line,column,type,code,message --slug=superdav-ai-translations --mode=new`
- `wp plugin check superdav-ai-translations --format=json --fields=file,line,column,type,code,message --slug=superdav-ai-translations --mode=new --include-experimental`
- `wp plugin activate superdav-ai-translations --network && wp plugin deactivate superdav-ai-translations --network`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.0 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Plugin rebranded from "Gratis AI Plugin Translations" to "Superdav AI Translations"
  * Updated package name to `ultimatemultisite/superdav-ai-translations`
  * WP-CLI commands now use `wp superdav-ai-translations` namespace

* **New Features**
  * Automated translation package installation upon refresh completion

* **Improvements**
  * Enhanced cache management using WordPress native APIs
  * Improved admin UI with updated translation status messaging

* **Documentation**
  * Updated all guides, README, and test documentation for new branding and commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->