### PR TITLE
GH#32: fix: preserve locale list shape

### DIFF
--- a/src/class-cli.php
+++ b/src/class-cli.php
@@ -416,10 +416,11 @@ class CLI {
 			}
 		}
 
-		$locales = array_values(
+		$excluded_locales = [ 'en_US', 'en', 'site-default' ];
+		$locales          = array_values(
 			array_diff(
 				array_filter( array_unique( $locales ) ),
-				[ 'en_US', 'en', 'site-default' ]
+				$excluded_locales
 			)
 		);
 


### PR DESCRIPTION
## Summary

Kept locale exclusion explicit while preserving the source-side array_values() reindexing for CLI locale discovery.

## Files Changed

src/class-cli.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** php -l src/class-cli.php; php -r locale reindex assertion

Resolves #32


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.0 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 2m and 25,298 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Cleaned up locale filtering logic for clearer handling of excluded locales.
  * No change to the locales returned or fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->