### PR TITLE
GH#33: fix: validate translation status payload shape

### DIFF
--- a/src/class-translation-api-client.php
+++ b/src/class-translation-api-client.php
@@ -203,7 +203,7 @@ class Translation_API_Client {
             );
         }
 
-        if (!is_array($data)) {
+        if (!$this->is_associative_response($data)) {
             return new \WP_Error(
                 'invalid_response',
                 __('Invalid response from translation status endpoint', 'superdav-ai-translations')
@@ -312,5 +312,20 @@ class Translation_API_Client {
         $cache_keys = array_values(array_unique(array_filter($cache_keys, 'is_string')));
 
         update_site_option(self::CACHE_KEYS_OPTION, $cache_keys);
+    }
+
+    /**
+     * Confirm a decoded API response is an object-shaped array.
+     *
+     * @since 1.2.0
+     * @param mixed $data Decoded JSON response payload.
+     * @return bool True when the response can be cached and returned.
+     */
+    private function is_associative_response($data): bool {
+        if (!is_array($data) || [] === $data) {
+            return false;
+        }
+
+        return array_keys($data) !== range(0, count($data) - 1);
     }
 }


### PR DESCRIPTION
## Summary

Added an object-shaped response guard before caching translation status API responses so scalar, empty, or list-shaped decoded JSON is rejected with WP_Error.

## Files Changed

src/class-translation-api-client.php

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** php -l src/class-translation-api-client.php; php -l superdav-ai-translations.php && php -l src/class-admin-settings.php && php -l src/class-cli.php && php -l src/class-translation-manager.php

Resolves #33


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.22.0 plugin for [OpenCode](https://opencode.ai) v1.17.9 with gpt-5.5 spent 3m and 52,280 tokens on this as a headless worker.