### PR TITLE
docs: update plugin author metadata

### DIFF
--- a/superdav-ai-language-packs.php
+++ b/superdav-ai-language-packs.php
@@ -6,7 +6,7 @@
  * Version: 1.0.0
  * Requires at least: 5.8
  * Requires PHP: 7.4
- * Author: Ultimate Multisite
+ * Author: superdav42
  * Author URI: https://ultimatemultisite.com
  * License: GPL-2.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
## Summary
- Update the WordPress plugin header `Author` value to `superdav42`.
- Keep the existing Ultimate Multisite author URI for the public ownership reference.

## Verification
- `php -l superdav-ai-language-packs.php`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.29.41 plugin for [OpenCode](https://opencode.ai) v1.17.11


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the plugin’s author information in the metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->