### PR TITLE
Improve admin status page

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,28 +53,33 @@ composer require ultimate-multisite/superdav-ai-plugin-translations
 ### For Multisite
 
 1. Network activate the plugin from **My Sites > Network Admin > Plugins**
-2. Configure settings at **My Sites > Network Admin > Settings > AI Translations**
+2. View translation status at **My Sites > Network Admin > Settings > AI Translations**
 
-## Configuration
+## Status and Configuration
 
-### Settings
+### Status Page
 
 Navigate to **Settings > AI Translations** (single site) or **Network Admin > Settings > AI Translations** (multisite).
 
-| Setting | Description | Default |
-|---------|-------------|---------|
-| **Enable AI Translations** | Toggle automatic translation downloads | Enabled |
-| **Fill Incomplete Translations** | Provide AI translations for missing strings in partial translations | Enabled |
-| **API Base URL** | The translation server endpoint | `https://translate.ultimatemultisite.com/wp-json/gratis-ai-translations/v1` |
-| **Cache Duration** | How long to cache translation checks | 1 hour |
+The page is read-only. It reports service health, background scan activity, detected non-English locales, queued translation jobs, and installed AI language packs. It does not include a manual refresh button or write plugin options.
 
-### Constants
+### Code Configuration
+
+The plugin runs automatically. Site owners can adjust behaviour from `wp-config.php`, a small must-use plugin, or another trusted plugin:
+
+| Constant / Filter | Description | Default |
+|-------------------|-------------|---------|
+| `SD_AI_LANG_PACKS_API_BASE` | Custom translation server endpoint | `https://translate.ultimatemultisite.com/wp-json/sd-ai-lang-pack/v1` |
+| `sd_ai_lang_packs_enabled` | Enable or disable automatic translation checks | `true` |
+| `sd_ai_lang_packs_fill_incomplete` | Request AI translations for missing strings in incomplete official translations | `true` |
+| `sd_ai_lang_packs_cache_duration` | Cache duration for completed translation result sets | `HOUR_IN_SECONDS` |
+| `sd_ai_lang_packs_refresh_chunk_size` | Number of plugins processed per background cron chunk | `25` |
 
 You can define these in your `wp-config.php`:
 
 ```php
 // Custom API endpoint (if running your own server)
-define('SD_AI_LANG_PACKS_API_BASE', 'https://your-server.com/wp-json/gratis-ai-translations/v1');
+define('SD_AI_LANG_PACKS_API_BASE', 'https://your-server.com/wp-json/sd-ai-lang-pack/v1');
 ```
 
 ## WP-CLI Commands
@@ -110,7 +115,7 @@ wp superdav-ai-plugin-translations status-plugin woocommerce de_DE
 
 - **Translation_Manager**: Hooks into WordPress update system, manages translation lifecycle
 - **Translation_API_Client**: Communicates with the translation server
-- **Admin_Settings**: Settings page and configuration UI
+- **Admin_Settings**: Read-only admin status page
 - **CLI**: WP-CLI command handlers
 
 ### Hooks Used

--- a/readme.txt
+++ b/readme.txt
@@ -77,7 +77,7 @@ Translations are cached locally on your server. No data is stored on external se
 = For Multisite =
 
 1. Network activate the plugin from **My Sites > Network Admin > Plugins**
-2. Configure settings at **My Sites > Network Admin > Settings > AI Translations**
+2. View translation status at **My Sites > Network Admin > Settings > AI Translations**
 
 == Frequently Asked Questions ==
 
@@ -107,8 +107,8 @@ The plugin is free. The translation service is currently offered at no cost whil
 
 == Screenshots ==
 
-1. Settings page showing API status and statistics
-2. Translation queue showing pending translations
+1. Status page showing service health, background activity, detected locales, and translation statistics
+2. Translation table showing installed AI language packs and queued translations
 
 == Changelog ==
 
@@ -118,7 +118,7 @@ The plugin is free. The translation service is currently offered at no cost whil
 * New: Detect WordPress.org vs premium plugins; source is included in batch requests to the server
 * New: Chunked, batched translation refresh to handle large plugin lists without timeouts
 * New: Rich admin status page with per-plugin and per-locale translation counts
-* New: "Check for updates now" button that forces a fresh WordPress update check before triggering an AI refresh
+* New: Background activity reporting for chunked translation refreshes
 * New: Default auto_approve=false — AI translations wait for server-side approval before downloading
 * New: Allow downloads from translation server on private-IP/local networks (development environments)
 * New: Full multisite support with network-admin settings page

--- a/src/class-admin-settings.php
+++ b/src/class-admin-settings.php
@@ -65,46 +65,6 @@ class Admin_Settings {
 		add_action( 'admin_notices', [ $this, 'display_admin_notices' ] );
 		add_action( 'network_admin_notices', [ $this, 'display_admin_notices' ] );
 
-		// "Refresh translation status" action handler.
-		add_action( 'admin_post_sd_ai_lang_packs_refresh', [ $this, 'handle_refresh_action' ] );
-	}
-
-	/**
-	 * Handle the "Refresh translation status" button submission.
-	 *
-	 * Schedules an immediate async AI translation refresh. The refresh is kept
-	 * async via cron because it queries every plugin against the translation
-	 * server.
-	 *
-	 * @since 1.0.0
-	 * @return void
-	 */
-	public function handle_refresh_action(): void {
-		$cap = is_multisite() ? 'manage_network_options' : 'manage_options';
-		if ( ! current_user_can( $cap ) ) {
-			wp_die( esc_html__( 'You do not have permission to perform this action.', 'superdav-ai-language-packs' ) );
-		}
-		check_admin_referer( 'sd_ai_lang_packs_refresh' );
-
-		// Clear the cached AI translation results so the next refresh
-		// recomputes fully against current WordPress translation data.
-		delete_site_transient( 'sd_ai_lang_packs_translations_cache' );
-
-		// Schedule the async AI refresh (replace any existing).
-		wp_clear_scheduled_hook( 'sd_ai_lang_packs_refresh_cache' );
-		wp_schedule_single_event( time() + 1, 'sd_ai_lang_packs_refresh_cache' );
-
-		// Nudge WP Cron so the event runs in the background instead of
-		// waiting for the next page load. Non-blocking.
-		if ( function_exists( 'spawn_cron' ) ) {
-			spawn_cron();
-		}
-
-		$redirect = is_multisite()
-			? network_admin_url( 'settings.php?page=superdav-ai-language-packs&refreshed=1' )
-			: admin_url( 'options-general.php?page=superdav-ai-language-packs&refreshed=1' );
-		wp_safe_redirect( $redirect );
-		exit;
 	}
 
 	/**
@@ -169,83 +129,209 @@ class Admin_Settings {
 	 * @return void
 	 */
 	public function render_status_page(): void {
-		$api_status   = $this->api_client->check_api_status();
-		$api_healthy  = ! is_wp_error( $api_status );
-		$stats        = $this->get_translation_statistics();
-		$local        = $this->get_local_translation_details();
-		$plugin_names = $this->get_plugin_name_map();
-		$pending      = (int) $stats['pending_count'];
-		$action_url   = admin_url( 'admin-post.php' );
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$just_refreshed = isset( $_GET['refreshed'] ) && '1' === $_GET['refreshed'];
+		$api_status        = $this->api_client->check_api_status();
+		$api_healthy       = ! is_wp_error( $api_status );
+		$local             = $this->get_local_translation_details();
+		$stats             = $this->get_translation_statistics( $local );
+		$plugin_names      = $this->get_plugin_name_map();
+		$pending           = (int) $stats['pending_count'];
+		$refresh_status    = $this->get_refresh_status();
+		$monitored_locales = $this->get_monitored_locales();
+		$cron_disabled     = defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON;
 		?>
-		<div class="wrap">
-			<h1>
-				<?php echo esc_html( get_admin_page_title() ); ?>
-				<form method="post" action="<?php echo esc_url( $action_url ); ?>" style="display:inline-block;margin-left:12px;">
-					<?php wp_nonce_field( 'sd_ai_lang_packs_refresh' ); ?>
-					<input type="hidden" name="action" value="sd_ai_lang_packs_refresh">
-					<button type="submit" class="page-title-action">
-						<?php esc_html_e( 'Refresh translation status', 'superdav-ai-language-packs' ); ?>
-					</button>
-				</form>
-			</h1>
+		<div class="wrap sd-ai-lang-packs-status">
+			<h1><?php echo esc_html( get_admin_page_title() ); ?></h1>
 
-			<?php if ( $just_refreshed ) : ?>
-				<div class="notice notice-success is-dismissible">
-					<p><?php esc_html_e( 'AI translation refresh is running in the background — reload this page in a few seconds to see the latest status.', 'superdav-ai-language-packs' ); ?></p>
-				</div>
-			<?php endif; ?>
+			<style>
+				.sd-ai-lang-packs-status .card {
+					max-width: 960px;
+					padding: 16px 20px;
+				}
+				.sd-ai-lang-packs-description {
+					max-width: 800px;
+					font-size: 14px;
+					margin-bottom: 20px;
+				}
+				.sd-ai-lang-packs-status-line {
+					display: flex;
+					align-items: center;
+					gap: 8px;
+					margin: 0;
+				}
+				.sd-ai-lang-packs-status-line .dashicons-yes-alt {
+					color: #00a32a;
+				}
+				.sd-ai-lang-packs-status-line .dashicons-warning {
+					color: #d63638;
+				}
+				.sd-ai-lang-packs-status-line .dashicons-update {
+					color: #2271b1;
+				}
+				.sd-ai-lang-packs-summary {
+					display: grid;
+					grid-template-columns: repeat( auto-fit, minmax( 140px, 1fr ) );
+					gap: 16px;
+					margin: 0 0 20px;
+				}
+				.sd-ai-lang-packs-stat {
+					background: #f6f7f7;
+					border: 1px solid #dcdcde;
+					border-radius: 4px;
+					padding: 12px;
+					text-align: center;
+				}
+				.sd-ai-lang-packs-stat-number {
+					font-size: 28px;
+					font-weight: 600;
+					line-height: 1.1;
+				}
+				.sd-ai-lang-packs-stat-label,
+				.sd-ai-lang-packs-muted {
+					color: #646970;
+				}
+				.sd-ai-lang-packs-stat-label {
+					font-size: 13px;
+					margin-top: 2px;
+				}
+				.sd-ai-lang-packs-progress {
+					background: #f0f0f1;
+					border-radius: 999px;
+					height: 10px;
+					overflow: hidden;
+					margin: 12px 0;
+				}
+				.sd-ai-lang-packs-progress-bar {
+					background: #2271b1;
+					height: 10px;
+				}
+				.sd-ai-lang-packs-meta-list {
+					display: grid;
+					grid-template-columns: repeat( auto-fit, minmax( 220px, 1fr ) );
+					gap: 8px 20px;
+					margin: 12px 0 0;
+				}
+				.sd-ai-lang-packs-meta-list dt {
+					font-weight: 600;
+				}
+				.sd-ai-lang-packs-meta-list dd {
+					margin: 0;
+				}
+				.sd-ai-lang-packs-locale-list {
+					margin-bottom: 0;
+				}
+				.sd-ai-lang-packs-table {
+					margin-top: 4px;
+				}
+				.sd-ai-lang-packs-table .column-strings {
+					text-align: right;
+				}
+			</style>
 
-			<p class="description" style="max-width:800px;font-size:14px;margin-bottom:20px;">
-				<?php esc_html_e( 'Your plugins are being translated automatically by AI whenever official translations are missing or incomplete. There is nothing to configure — translations are requested and downloaded in the background. Use this page to check progress.', 'superdav-ai-language-packs' ); ?>
+			<p class="description sd-ai-lang-packs-description">
+				<?php esc_html_e( 'Your plugins are translated automatically by AI whenever official translations are missing or incomplete. There is nothing to configure on this page — use it to review service health, background activity, detected locales, and installed AI language packs.', 'superdav-ai-language-packs' ); ?>
 			</p>
 
-			<div class="card" style="max-width:800px;margin-top:20px;padding:12px 20px;">
-				<h2 style="margin-top:0;"><?php esc_html_e( 'Service Status', 'superdav-ai-language-packs' ); ?></h2>
+			<div class="card">
+				<h2><?php esc_html_e( 'Service Status', 'superdav-ai-language-packs' ); ?></h2>
 				<?php if ( $api_healthy ) : ?>
-					<p style="margin:0;">
-						<span class="dashicons dashicons-yes-alt" style="color:#00a32a;vertical-align:middle;"></span>
+					<p class="sd-ai-lang-packs-status-line">
+						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
 						<?php esc_html_e( 'Translation service is online and ready.', 'superdav-ai-language-packs' ); ?>
 					</p>
 				<?php else : ?>
-					<p style="margin:0;">
-						<span class="dashicons dashicons-warning" style="color:#d63638;vertical-align:middle;"></span>
+					<p class="sd-ai-lang-packs-status-line">
+						<span class="dashicons dashicons-warning" aria-hidden="true"></span>
 						<?php esc_html_e( 'Translation service is currently unavailable. Translations will resume automatically when the service recovers.', 'superdav-ai-language-packs' ); ?>
 					</p>
 					<?php if ( is_wp_error( $api_status ) ) : ?>
-						<p><code><?php echo esc_html( $api_status->get_error_message() ); ?></code></p>
+						<p class="description"><code><?php echo esc_html( $api_status->get_error_message() ); ?></code></p>
 					<?php endif; ?>
 				<?php endif; ?>
 			</div>
 
-			<div class="card" style="max-width:800px;margin-top:20px;padding:12px 20px;">
-				<h2 style="margin-top:0;"><?php esc_html_e( 'Translation Progress', 'superdav-ai-language-packs' ); ?></h2>
+			<div class="card">
+				<h2><?php esc_html_e( 'Background Activity', 'superdav-ai-language-packs' ); ?></h2>
+				<?php if ( 'running' === $refresh_status['status'] ) : ?>
+					<p class="sd-ai-lang-packs-status-line">
+						<span class="dashicons dashicons-update" aria-hidden="true"></span>
+						<?php esc_html_e( 'A background translation scan is currently processing installed plugins.', 'superdav-ai-language-packs' ); ?>
+					</p>
+					<div class="sd-ai-lang-packs-progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="<?php echo esc_attr( (string) $refresh_status['progress'] ); ?>">
+						<div class="sd-ai-lang-packs-progress-bar" style="width: <?php echo esc_attr( (string) $refresh_status['progress'] ); ?>%;"></div>
+					</div>
+					<p class="sd-ai-lang-packs-muted">
+						<?php
+						printf(
+							/* translators: 1: Processed plugin count, 2: Total plugin count. */
+							esc_html__( '%1$s of %2$s plugins processed in the current scan.', 'superdav-ai-language-packs' ),
+							esc_html( number_format_i18n( (int) $refresh_status['processed'] ) ),
+							esc_html( number_format_i18n( (int) $refresh_status['total'] ) )
+						);
+						?>
+					</p>
+				<?php elseif ( 'scheduled' === $refresh_status['status'] ) : ?>
+					<p class="sd-ai-lang-packs-status-line">
+						<span class="dashicons dashicons-clock" aria-hidden="true"></span>
+						<?php esc_html_e( 'The next background translation scan is scheduled.', 'superdav-ai-language-packs' ); ?>
+					</p>
+				<?php else : ?>
+					<p class="sd-ai-lang-packs-status-line">
+						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
+						<?php esc_html_e( 'Background translation activity is idle. WordPress will schedule future scans automatically when translation checks or locale changes require them.', 'superdav-ai-language-packs' ); ?>
+					</p>
+				<?php endif; ?>
 
-				<div style="display:flex;gap:32px;margin-bottom:20px;flex-wrap:wrap;">
-					<div style="text-align:center;">
-						<div style="font-size:28px;font-weight:600;line-height:1.1;"><?php echo esc_html( number_format_i18n( count( $local ) ) ); ?></div>
-						<div style="color:#646970;font-size:13px;margin-top:2px;"><?php esc_html_e( 'translations active', 'superdav-ai-language-packs' ); ?></div>
+				<?php if ( $cron_disabled ) : ?>
+					<div class="notice notice-warning inline">
+						<p><?php esc_html_e( 'WP-Cron spawning is disabled. Make sure a server cron job runs wp-cron.php so background translation scans can finish.', 'superdav-ai-language-packs' ); ?></p>
 					</div>
-					<div style="text-align:center;">
-						<div style="font-size:28px;font-weight:600;line-height:1.1;"><?php echo esc_html( number_format_i18n( (int) $stats['plugins_count'] ) ); ?></div>
-						<div style="color:#646970;font-size:13px;margin-top:2px;"><?php esc_html_e( 'plugins covered', 'superdav-ai-language-packs' ); ?></div>
+				<?php endif; ?>
+
+				<dl class="sd-ai-lang-packs-meta-list">
+					<div>
+						<dt><?php esc_html_e( 'Last completed check', 'superdav-ai-language-packs' ); ?></dt>
+						<dd><?php echo esc_html( $stats['last_check'] ); ?></dd>
 					</div>
-					<div style="text-align:center;">
-						<div style="font-size:28px;font-weight:600;line-height:1.1;"><?php echo esc_html( number_format_i18n( (int) $stats['languages_count'] ) ); ?></div>
-						<div style="color:#646970;font-size:13px;margin-top:2px;"><?php esc_html_e( 'languages', 'superdav-ai-language-packs' ); ?></div>
+					<div>
+						<dt><?php esc_html_e( 'Plugins scanned last run', 'superdav-ai-language-packs' ); ?></dt>
+						<dd><?php echo esc_html( number_format_i18n( (int) $stats['plugins_checked'] ) ); ?></dd>
 					</div>
-					<?php if ( $pending > 0 ) : ?>
-						<div style="text-align:center;">
-							<div style="font-size:28px;font-weight:600;line-height:1.1;color:#2271b1;"><?php echo esc_html( number_format_i18n( $pending ) ); ?></div>
-							<div style="color:#646970;font-size:13px;margin-top:2px;"><?php esc_html_e( 'queued', 'superdav-ai-language-packs' ); ?></div>
-						</div>
-					<?php endif; ?>
+					<div>
+						<dt><?php esc_html_e( 'Next scheduled scan', 'superdav-ai-language-packs' ); ?></dt>
+						<dd><?php echo esc_html( $this->format_scheduled_time( $refresh_status['next_scheduled'] ) ); ?></dd>
+					</div>
+				</dl>
+			</div>
+
+			<div class="card">
+				<h2><?php esc_html_e( 'Translation Progress', 'superdav-ai-language-packs' ); ?></h2>
+
+				<div class="sd-ai-lang-packs-summary">
+					<div class="sd-ai-lang-packs-stat">
+						<div class="sd-ai-lang-packs-stat-number"><?php echo esc_html( number_format_i18n( count( $local ) ) ); ?></div>
+						<div class="sd-ai-lang-packs-stat-label"><?php esc_html_e( 'translations active', 'superdav-ai-language-packs' ); ?></div>
+					</div>
+					<div class="sd-ai-lang-packs-stat">
+						<div class="sd-ai-lang-packs-stat-number"><?php echo esc_html( number_format_i18n( (int) $stats['plugins_count'] ) ); ?></div>
+						<div class="sd-ai-lang-packs-stat-label"><?php esc_html_e( 'plugins covered', 'superdav-ai-language-packs' ); ?></div>
+					</div>
+					<div class="sd-ai-lang-packs-stat">
+						<div class="sd-ai-lang-packs-stat-number"><?php echo esc_html( number_format_i18n( (int) $stats['languages_count'] ) ); ?></div>
+						<div class="sd-ai-lang-packs-stat-label"><?php esc_html_e( 'languages', 'superdav-ai-language-packs' ); ?></div>
+					</div>
+					<div class="sd-ai-lang-packs-stat">
+						<div class="sd-ai-lang-packs-stat-number"><?php echo esc_html( number_format_i18n( $pending ) ); ?></div>
+						<div class="sd-ai-lang-packs-stat-label"><?php esc_html_e( 'queued', 'superdav-ai-language-packs' ); ?></div>
+					</div>
+					<div class="sd-ai-lang-packs-stat">
+						<div class="sd-ai-lang-packs-stat-number"><?php echo esc_html( number_format_i18n( (int) $stats['available_count'] ) ); ?></div>
+						<div class="sd-ai-lang-packs-stat-label"><?php esc_html_e( 'available last check', 'superdav-ai-language-packs' ); ?></div>
+					</div>
 				</div>
 
 				<?php if ( $pending > 0 ) : ?>
-					<div class="notice notice-info inline" style="margin:0 0 16px;padding:8px 12px;">
-						<p style="margin:0;">
+					<div class="notice notice-info inline">
+						<p>
 							<?php
 							printf(
 								esc_html(
@@ -267,44 +353,62 @@ class Admin_Settings {
 				<?php endif; ?>
 
 				<?php if ( ! empty( $local ) ) : ?>
-					<table class="widefat striped" style="margin-top:4px;">
+					<table class="widefat striped sd-ai-lang-packs-table">
+						<caption class="screen-reader-text"><?php esc_html_e( 'Installed AI plugin language packs', 'superdav-ai-language-packs' ); ?></caption>
 						<thead>
 							<tr>
-								<th><?php esc_html_e( 'Plugin', 'superdav-ai-language-packs' ); ?></th>
-								<th><?php esc_html_e( 'Language', 'superdav-ai-language-packs' ); ?></th>
-								<th style="text-align:right;"><?php esc_html_e( 'Strings translated', 'superdav-ai-language-packs' ); ?></th>
+								<th scope="col"><?php esc_html_e( 'Plugin', 'superdav-ai-language-packs' ); ?></th>
+								<th scope="col"><?php esc_html_e( 'Language', 'superdav-ai-language-packs' ); ?></th>
+								<th scope="col" class="column-strings"><?php esc_html_e( 'Strings translated', 'superdav-ai-language-packs' ); ?></th>
 							</tr>
 						</thead>
 						<tbody>
 							<?php foreach ( $local as $item ) : ?>
 								<tr>
-									<td><?php echo esc_html( $plugin_names[ $item['textdomain'] ] ?? $item['textdomain'] ); ?></td>
-									<td><?php echo esc_html( $item['locale'] ); ?></td>
-									<td style="text-align:right;"><?php echo esc_html( number_format_i18n( $item['strings'] ) ); ?></td>
+									<td>
+										<strong><?php echo esc_html( $plugin_names[ $item['textdomain'] ] ?? $item['textdomain'] ); ?></strong><br>
+										<span class="sd-ai-lang-packs-muted"><?php echo esc_html( $item['textdomain'] ); ?></span>
+									</td>
+									<td><?php echo esc_html( $this->format_locale_label( $item['locale'] ) ); ?></td>
+									<td class="column-strings"><?php echo esc_html( number_format_i18n( $item['strings'] ) ); ?></td>
 								</tr>
 							<?php endforeach; ?>
 						</tbody>
 					</table>
 				<?php elseif ( 0 === $pending ) : ?>
-					<p style="color:#646970;font-style:italic;margin:0;">
-						<?php esc_html_e( 'No AI translations downloaded yet. Click "Refresh translation status" to start.', 'superdav-ai-language-packs' ); ?>
+					<p class="sd-ai-lang-packs-muted">
+						<?php esc_html_e( 'No AI translations have been downloaded yet. They will appear here after WordPress detects missing translations and the background scan completes.', 'superdav-ai-language-packs' ); ?>
 					</p>
 				<?php endif; ?>
-
-				<p style="margin-top:12px;margin-bottom:0;color:#646970;font-size:12px;">
-					<?php
-					printf(
-						/* translators: 1: Human-readable time since last check (e.g. "5 minutes ago"), 2: Number of plugins scanned */
-						esc_html__( 'Last checked: %1$s — %2$s plugins scanned.', 'superdav-ai-language-packs' ),
-						esc_html( $stats['last_check'] ),
-						esc_html( number_format_i18n( (int) $stats['plugins_checked'] ) )
-					);
-					?>
-				</p>
 			</div>
 
-			<div class="card" style="max-width:800px;margin-top:20px;padding:12px 20px;">
-				<h2 style="margin-top:0;"><?php esc_html_e( 'How It Works', 'superdav-ai-language-packs' ); ?></h2>
+			<div class="card">
+				<h2><?php esc_html_e( 'Locale Coverage', 'superdav-ai-language-packs' ); ?></h2>
+				<p><?php esc_html_e( 'These non-English locales are currently detected from the site language, network site languages, and user profile language preferences.', 'superdav-ai-language-packs' ); ?></p>
+				<?php if ( empty( $monitored_locales ) ) : ?>
+					<p class="sd-ai-lang-packs-muted"><?php esc_html_e( 'Only English or site-default locales are currently detected, so no AI plugin language packs are needed.', 'superdav-ai-language-packs' ); ?></p>
+				<?php else : ?>
+					<ul class="sd-ai-lang-packs-locale-list">
+						<?php foreach ( $monitored_locales as $locale => $locale_data ) : ?>
+							<li>
+								<strong><?php echo esc_html( $this->format_locale_label( $locale ) ); ?></strong>
+								<span class="sd-ai-lang-packs-muted">
+									<?php
+									printf(
+										/* translators: %s: Comma-separated locale sources. */
+										esc_html__( 'Detected from: %s', 'superdav-ai-language-packs' ),
+										esc_html( implode( ', ', array_map( [ $this, 'get_locale_source_label' ], array_keys( $locale_data['sources'] ) ) ) )
+									);
+									?>
+								</span>
+							</li>
+						<?php endforeach; ?>
+					</ul>
+				<?php endif; ?>
+			</div>
+
+			<div class="card">
+				<h2><?php esc_html_e( 'How It Works', 'superdav-ai-language-packs' ); ?></h2>
 				<ol>
 					<li><?php esc_html_e( 'When WordPress checks for plugin updates, this plugin checks whether translations are needed.', 'superdav-ai-language-packs' ); ?></li>
 					<li><?php esc_html_e( 'For any plugin without complete official translations, AI-generated translations are requested automatically.', 'superdav-ai-language-packs' ); ?></li>
@@ -314,9 +418,14 @@ class Admin_Settings {
 				</ol>
 			</div>
 
-			<div class="card" style="max-width:800px;margin-top:20px;padding:12px 20px;">
-				<h2 style="margin-top:0;"><?php esc_html_e( 'Privacy Notice', 'superdav-ai-language-packs' ); ?></h2>
-				<p style="margin:0;"><?php esc_html_e( 'This plugin sends the following data to the translation server: plugin metadata (name, version, textdomain), the site URL, and the WordPress version. No personal data or site content is transmitted. Translations are cached on your server.', 'superdav-ai-language-packs' ); ?></p>
+			<div class="card">
+				<h2><?php esc_html_e( 'Privacy Notice', 'superdav-ai-language-packs' ); ?></h2>
+				<p><?php esc_html_e( 'This plugin sends plugin metadata (name, version, textdomain), the requested locale, the site URL, and the WordPress version to the translation service. No personal data, user data, or site content is transmitted. Translations are cached on your server.', 'superdav-ai-language-packs' ); ?></p>
+				<p class="sd-ai-lang-packs-muted">
+					<a href="<?php echo esc_url( 'https://ultimatemultisite.com/terms' ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Terms of Use', 'superdav-ai-language-packs' ); ?></a>
+					<?php echo esc_html_x( '·', 'separator between external policy links', 'superdav-ai-language-packs' ); ?>
+					<a href="<?php echo esc_url( 'https://ultimatemultisite.com/privacy' ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Privacy Policy', 'superdav-ai-language-packs' ); ?></a>
+				</p>
 			</div>
 		</div>
 		<?php
@@ -326,28 +435,22 @@ class Admin_Settings {
 	 * Get translation statistics.
 	 *
 	 * @since 1.0.0
+	 * @param array<int, array{textdomain: string, locale: string, strings: int}> $details Local translation details.
 	 * @return array Statistics array.
 	 */
-	private function get_translation_statistics(): array {
-		$languages_dir = WP_CONTENT_DIR . '/languages/plugins';
-		$total         = 0;
-		$plugins       = [];
-		$languages     = [];
+	private function get_translation_statistics( array $details ): array {
+		$plugins   = [];
+		$languages = [];
 
-		if ( is_dir( $languages_dir ) ) {
-			$details = $this->get_local_translation_details();
-			$total   = count( $details );
-
-			foreach ( $details as $detail ) {
-				$plugins[]   = $detail['textdomain'];
-				$languages[] = $detail['locale'];
-			}
+		foreach ( $details as $detail ) {
+			$plugins[]   = $detail['textdomain'];
+			$languages[] = $detail['locale'];
 		}
 
 		$last_check_raw = get_site_option( 'sd_ai_lang_packs_last_check', null );
 
 		return [
-			'total_translations' => $total,
+			'total_translations' => count( $details ),
 			'plugins_count'      => count( array_unique( $plugins ) ),
 			'languages_count'    => count( array_unique( $languages ) ),
 			'plugins_checked'    => (int) get_site_option( 'sd_ai_lang_packs_plugins_checked', 0 ),
@@ -357,6 +460,230 @@ class Admin_Settings {
 				? human_time_diff( (int) strtotime( (string) $last_check_raw ), time() ) . ' ' . __( 'ago', 'superdav-ai-language-packs' )
 				: __( 'Never', 'superdav-ai-language-packs' ),
 		];
+	}
+
+	/**
+	 * Get background refresh status from the persisted cron state.
+	 *
+	 * @since 1.0.0
+	 * @return array{status: string, processed: int, total: int, progress: int, next_scheduled: int|null}
+	 */
+	private function get_refresh_status(): array {
+		$state          = get_site_option( 'sd_ai_lang_packs_refresh_state', null );
+		$next_scheduled = wp_next_scheduled( 'sd_ai_lang_packs_refresh_cache' );
+		$status         = $next_scheduled ? 'scheduled' : 'idle';
+		$processed      = 0;
+		$total          = 0;
+
+		if ( is_array( $state ) && isset( $state['plugins'] ) && is_array( $state['plugins'] ) ) {
+			$total     = count( $state['plugins'] );
+			$processed = min( max( (int) ( $state['offset'] ?? 0 ), 0 ), $total );
+
+			if ( $total > $processed ) {
+				$status = 'running';
+			}
+		}
+
+		$progress = $total > 0 ? (int) floor( ( $processed / $total ) * 100 ) : 0;
+		$progress = min( max( $progress, 0 ), 100 );
+
+		return [
+			'status'         => $status,
+			'processed'      => $processed,
+			'total'          => $total,
+			'progress'       => $progress,
+			'next_scheduled' => $next_scheduled ? (int) $next_scheduled : null,
+		];
+	}
+
+	/**
+	 * Format a scheduled cron timestamp for display.
+	 *
+	 * @since 1.0.0
+	 * @param int|null $timestamp Unix timestamp, or null when unscheduled.
+	 * @return string Human-readable schedule state.
+	 */
+	private function format_scheduled_time( ?int $timestamp ): string {
+		if ( empty( $timestamp ) ) {
+			return __( 'Not scheduled', 'superdav-ai-language-packs' );
+		}
+
+		if ( $timestamp <= time() ) {
+			return __( 'Due now', 'superdav-ai-language-packs' );
+		}
+
+		return sprintf(
+			/* translators: %s: Human-readable time until the scheduled event. */
+			__( 'in %s', 'superdav-ai-language-packs' ),
+			human_time_diff( time(), $timestamp )
+		);
+	}
+
+	/**
+	 * Get non-English locales that can trigger AI plugin translations.
+	 *
+	 * Mirrors Translation_Manager locale discovery for status visibility while
+	 * showing only the locales that require language packs.
+	 *
+	 * @since 1.0.0
+	 * @return array<string, array{sources: array<string, bool>}> Locale details keyed by locale code.
+	 */
+	private function get_monitored_locales(): array {
+		$locales = [];
+
+		$this->add_locale_source( $locales, get_locale(), 'site' );
+
+		$user_ids = get_users(
+			[
+				'fields'       => 'ID',
+				'meta_key'     => 'locale',
+				'meta_compare' => 'EXISTS',
+			]
+		);
+
+		foreach ( $user_ids as $user_id ) {
+			$user_locale = get_user_meta( (int) $user_id, 'locale', true );
+			if ( is_string( $user_locale ) ) {
+				$this->add_locale_source( $locales, $user_locale, 'user' );
+			}
+		}
+
+		if ( is_multisite() && function_exists( 'get_sites' ) ) {
+			$site_ids = get_sites(
+				[
+					'fields' => 'ids',
+					'number' => 0,
+				]
+			);
+
+			foreach ( $site_ids as $site_id ) {
+				$site_locale = get_blog_option( (int) $site_id, 'WPLANG', '' );
+				if ( is_string( $site_locale ) ) {
+					$this->add_locale_source( $locales, $site_locale, 'network_site' );
+				}
+			}
+		}
+
+		ksort( $locales );
+
+		return $locales;
+	}
+
+	/**
+	 * Add a locale source to the locale summary.
+	 *
+	 * @since 1.0.0
+	 * @param array<string, array{sources: array<string, bool>}> $locales Locale details, mutated in place.
+	 * @param string                                             $locale  Locale code.
+	 * @param string                                             $source  Source key.
+	 * @return void
+	 */
+	private function add_locale_source( array &$locales, string $locale, string $source ): void {
+		$locale = trim( $locale );
+		if ( ! $this->is_translation_locale( $locale ) ) {
+			return;
+		}
+
+		if ( ! isset( $locales[ $locale ] ) ) {
+			$locales[ $locale ] = [ 'sources' => [] ];
+		}
+
+		$locales[ $locale ]['sources'][ $source ] = true;
+	}
+
+	/**
+	 * Check whether a locale needs translated language packs.
+	 *
+	 * @since 1.0.0
+	 * @param string $locale Locale code.
+	 * @return bool True when AI translations can be requested for the locale.
+	 */
+	private function is_translation_locale( string $locale ): bool {
+		return '' !== $locale && ! in_array( $locale, [ 'en_US', 'en', 'site-default' ], true );
+	}
+
+	/**
+	 * Get a translated label for a locale source key.
+	 *
+	 * @since 1.0.0
+	 * @param string $source Source key.
+	 * @return string Human-readable source label.
+	 */
+	private function get_locale_source_label( string $source ): string {
+		switch ( $source ) {
+			case 'site':
+				return __( 'site language', 'superdav-ai-language-packs' );
+			case 'network_site':
+				return __( 'network site language', 'superdav-ai-language-packs' );
+			case 'user':
+				return __( 'user profile language', 'superdav-ai-language-packs' );
+			default:
+				return __( 'unknown source', 'superdav-ai-language-packs' );
+		}
+	}
+
+	/**
+	 * Format a locale code with a readable language name when possible.
+	 *
+	 * @since 1.0.0
+	 * @param string $locale Locale code.
+	 * @return string Locale label.
+	 */
+	private function format_locale_label( string $locale ): string {
+		$display_name = '';
+		$locale_tag   = str_replace( '_', '-', $locale );
+
+		if ( class_exists( '\Locale' ) ) {
+			$display_name = (string) \Locale::getDisplayName( $locale_tag, str_replace( '_', '-', get_user_locale() ) );
+		}
+
+		if ( '' === $display_name || strtolower( $display_name ) === strtolower( $locale ) ) {
+			$display_name = $this->get_language_name_fallback( $locale );
+		}
+
+		if ( '' === $display_name ) {
+			return $locale;
+		}
+
+		return sprintf(
+			/* translators: 1: Language display name, 2: Locale code. */
+			__( '%1$s (%2$s)', 'superdav-ai-language-packs' ),
+			$display_name,
+			$locale
+		);
+	}
+
+	/**
+	 * Fallback language names for common locales when PHP intl is unavailable.
+	 *
+	 * @since 1.0.0
+	 * @param string $locale Locale code.
+	 * @return string Language name, or empty string when unknown.
+	 */
+	private function get_language_name_fallback( string $locale ): string {
+		$language_code = strtolower( substr( $locale, 0, 2 ) );
+		$names         = [
+			'cs' => __( 'Czech', 'superdav-ai-language-packs' ),
+			'da' => __( 'Danish', 'superdav-ai-language-packs' ),
+			'de' => __( 'German', 'superdav-ai-language-packs' ),
+			'el' => __( 'Greek', 'superdav-ai-language-packs' ),
+			'es' => __( 'Spanish', 'superdav-ai-language-packs' ),
+			'fi' => __( 'Finnish', 'superdav-ai-language-packs' ),
+			'fr' => __( 'French', 'superdav-ai-language-packs' ),
+			'hu' => __( 'Hungarian', 'superdav-ai-language-packs' ),
+			'it' => __( 'Italian', 'superdav-ai-language-packs' ),
+			'ja' => __( 'Japanese', 'superdav-ai-language-packs' ),
+			'nl' => __( 'Dutch', 'superdav-ai-language-packs' ),
+			'pl' => __( 'Polish', 'superdav-ai-language-packs' ),
+			'pt' => __( 'Portuguese', 'superdav-ai-language-packs' ),
+			'ro' => __( 'Romanian', 'superdav-ai-language-packs' ),
+			'ru' => __( 'Russian', 'superdav-ai-language-packs' ),
+			'sv' => __( 'Swedish', 'superdav-ai-language-packs' ),
+			'tr' => __( 'Turkish', 'superdav-ai-language-packs' ),
+			'zh' => __( 'Chinese', 'superdav-ai-language-packs' ),
+		];
+
+		return $names[ $language_code ] ?? '';
 	}
 
 	/**
@@ -497,16 +824,33 @@ class Admin_Settings {
 	 * @return int Number of translated strings, or 0 on read/parse failure.
 	 */
 	private function count_mo_strings( string $mo_file ): int {
+		if ( ! is_readable( $mo_file ) ) {
+			return 0;
+		}
+
+		$mtime     = filemtime( $mo_file );
+		$size      = filesize( $mo_file );
+		$cache_key = 'mo_strings_' . md5( $mo_file . '|' . (string) $mtime . '|' . (string) $size );
+		$cached    = wp_cache_get( $cache_key, 'sd_ai_lang_packs' );
+
+		if ( false !== $cached ) {
+			return (int) $cached;
+		}
+
 		if ( ! class_exists( 'MO' ) ) {
 			require_once ABSPATH . WPINC . '/pomo/mo.php';
 		}
 
 		$mo = new \MO();
 		if ( ! $mo->import_from_file( $mo_file ) ) {
+			wp_cache_set( $cache_key, 0, 'sd_ai_lang_packs', HOUR_IN_SECONDS );
 			return 0;
 		}
 
-		return count( $mo->entries );
+		$count = count( $mo->entries );
+		wp_cache_set( $cache_key, $count, 'sd_ai_lang_packs', HOUR_IN_SECONDS );
+
+		return $count;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Remove the manual admin refresh action so the AI Translations admin page is status-only.
- Add status reporting for service health, background scan state, WP-Cron posture, detected non-English locales, queued jobs, and installed language packs.
- Improve the installed translations table with accessible headers, plugin textdomain context, readable locale labels, and cached `.mo` string counts.
- Update README/readme copy so docs describe a read-only status page and code-based configuration.

## Verification

- `php -l src/class-admin-settings.php && php -l src/class-translation-api-client.php && php -l src/class-translation-manager.php && php -l superdav-ai-language-packs.php`
- `git diff --check`
- `Grep` checks confirm no remaining manual refresh/status-button copy.

## Notes

- `vendor/bin/phpstan analyse --memory-limit=512M` is blocked on the current base configuration because `phpstan.neon.dist` excludes missing `tests` and `node_modules` paths.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.14 plugin for [OpenCode](https://opencode.ai) v1.17.12


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a read-only status page with clearer service health, translation progress, and background activity reporting.
  * Improved locale coverage and installed pack visibility in the admin view.

* **Bug Fixes**
  * Removed the manual refresh action and updated the page flow to rely on automatic background updates.
  * Refined translation statistics and status indicators for more accurate reporting.

* **Documentation**
  * Updated the README and plugin docs to match the new status-oriented interface and revised setup guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->