### PR TITLE
fix: allow single-site activation

### DIFF
--- a/superdav-ai-language-packs.php
+++ b/superdav-ai-language-packs.php
@@ -11,7 +11,6 @@
  * License: GPL-2.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: superdav-ai-language-packs
- * Network: true
  *
  * @package GratisAIPluginTranslations
  */


### PR DESCRIPTION
## Summary

- Removes the `Network: true` plugin header from `superdav-ai-language-packs.php` so WordPress no longer marks the plugin as network-only.

## Context

- File changed: `superdav-ai-language-packs.php`
- Pattern changed: WordPress plugin header metadata only; runtime plugin code is unchanged.

## Verification

- `php -l superdav-ai-language-packs.php`
- `php -l src/class-admin-settings.php`
- `php -l src/class-translation-api-client.php`
- `php -l src/class-translation-manager.php`
- `git diff --check`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.16 plugin for [OpenCode](https://opencode.ai) v1.17.13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the plugin metadata so it is no longer marked as a network-activated plugin in WordPress multisite environments.
  * No functional behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->