### PR TITLE
fix: use WordPress language directory constant

### DIFF
--- a/src/class-admin-settings.php
+++ b/src/class-admin-settings.php
@@ -697,7 +697,7 @@ class Admin_Settings {
 	 * @return array<int, array{textdomain: string, locale: string, strings: int}>
 	 */
 	private function get_local_translation_details(): array {
-		$languages_dir = WP_CONTENT_DIR . '/languages/plugins';
+		$languages_dir = WP_LANG_DIR . '/plugins';
 		$details       = [];
 
 		if ( ! is_dir( $languages_dir ) ) {
@@ -793,7 +793,7 @@ class Admin_Settings {
 	 * @return string|null Absolute .mo path, or null if no file exists.
 	 */
 	private function find_translation_file( string $textdomain, string $locale, string $slug = '' ): ?string {
-		$languages_dir = WP_CONTENT_DIR . '/languages/plugins';
+		$languages_dir = WP_LANG_DIR . '/plugins';
 		$candidates    = [
 			$languages_dir . '/' . $textdomain . '-' . $locale . '.mo',
 		];

--- a/src/class-translation-manager.php
+++ b/src/class-translation-manager.php
@@ -886,7 +886,7 @@ class Translation_Manager {
      * @return void
      */
     public function cleanup_old_translations(): void {
-        $languages_dir = WP_CONTENT_DIR . '/languages/plugins';
+        $languages_dir = WP_LANG_DIR . '/plugins';
 
         if (!is_dir($languages_dir)) {
             return;


### PR DESCRIPTION
## Summary
- Use WP_LANG_DIR . '/plugins' for plugin translation paths in the admin status page.
- Use WP_LANG_DIR . '/plugins' when cleaning up legacy AI translation files.
- Removes hardcoded WP_CONTENT_DIR . '/languages/plugins' references flagged by WordPress.org review.

## Verification
- php -l src/class-admin-settings.php
- php -l src/class-translation-manager.php
- rg "WP_CONTENT_DIR\s*\.\s*['\"]/?languages/plugins|WP_CONTENT_DIR.*/languages/plugins" --glob '*.php'
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.31.22 plugin for [OpenCode](https://opencode.ai) v1.17.13


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of installed translation files so the admin status page shows more accurate language information.
  * Updated translation cleanup to look in the correct WordPress language directory, helping remove older language files more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->