### PR TITLE
t001: improve service disclosures and release archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,10 +134,10 @@ Translations are prioritized based on plugin popularity:
 
 ## Privacy
 
-- Only plugin metadata (name, version, textdomain) is sent to the translation server
-- No personal data or site content is transmitted
-- Translations are cached locally on your server
-- Site URL is sent for usage analytics only
+- The translation service receives plugin text domains, installed versions, update-source classification, requested locale codes, the site URL, and the WordPress version.
+- The request body does not include user IDs, names, email addresses, passwords, site content, posts, comments, or database records. The site's URL and the connection IP address received by the service can identify an installation.
+- The plugin stores its cache and downloaded language packs locally. The service provider's handling, retention, and deletion of request data are governed by its [Privacy Policy](https://ultimatemultisite.com/privacy) and [Terms of Use](https://ultimatemultisite.com/terms).
+- Deactivate the plugin to stop its external requests. Developers can disable automatic translation checks with the `sd_ai_lang_packs_enabled` filter.
 
 ## Server Requirements
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ The plugin runs automatically. Site owners can adjust behaviour from `wp-config.
 | Constant / Filter | Description | Default |
 |-------------------|-------------|---------|
 | `SD_AI_LANG_PACKS_API_BASE` | Custom translation server endpoint | `https://translate.ultimatemultisite.com/wp-json/sd-ai-lang-pack/v1` |
-| `sd_ai_lang_packs_enabled` | Enable or disable automatic translation checks | `true` |
 | `sd_ai_lang_packs_fill_incomplete` | Request AI translations for missing strings in incomplete official translations | `true` |
 | `sd_ai_lang_packs_cache_duration` | Cache duration for completed translation result sets | `HOUR_IN_SECONDS` |
 | `sd_ai_lang_packs_refresh_chunk_size` | Number of plugins processed per background cron chunk | `25` |
@@ -134,10 +133,10 @@ Translations are prioritized based on plugin popularity:
 
 ## Privacy
 
-- The translation service receives plugin text domains, installed versions, update-source classification, requested locale codes, the site URL, and the WordPress version.
-- The request body does not include user IDs, names, email addresses, passwords, site content, posts, comments, or database records. The site's URL and the connection IP address received by the service can identify an installation.
+- The translation service receives plugin text domains, installed versions, update-source classification when available, and requested locale codes.
+- The request body does not include the site URL, WordPress version, user IDs, names, email addresses, passwords, site content, posts, comments, or database records. The service receives the connection IP address as part of handling an HTTP request.
 - The plugin stores its cache and downloaded language packs locally. The service provider's handling, retention, and deletion of request data are governed by its [Privacy Policy](https://ultimatemultisite.com/privacy) and [Terms of Use](https://ultimatemultisite.com/terms).
-- Deactivate the plugin to stop its external requests. Developers can disable automatic translation checks with the `sd_ai_lang_packs_enabled` filter.
+- Deactivate the plugin to stop its external requests.
 
 ## Server Requirements
 

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,8 @@
             "/.*",
             "/*",
             "!/LICENSE",
+            "!/assets/",
+            "!/assets/**",
             "!/readme.txt",
             "!/src/",
             "!/src/**",

--- a/readme.txt
+++ b/readme.txt
@@ -31,16 +31,25 @@ The official WordPress translation platform (translate.wordpress.org) relies on 
 
 = External Service Usage =
 
-This plugin relies on an external service to generate translations:
+This plugin requires the translation service at https://translate.ultimatemultisite.com to check availability and request AI-generated plugin language packs. Requests are made automatically after activation and during scheduled translation checks when the plugin is enabled.
+
+The service receives:
+
+* Plugin text domain and installed version for plugins that need a language pack
+* Whether each plugin uses WordPress.org updates or another update source
+* Requested locale codes, including locales discovered from site, network-site, and user-profile language settings
+* The site's URL and WordPress version
+
+The request body does not include user IDs, names, email addresses, passwords, site content, posts, comments, or database records. However, a site URL and the connection IP address received by the service can identify an installation and should be treated as installation data.
+
+The plugin stores its cache and downloaded language packs locally. The service provider's handling, retention, and deletion of request data are governed by its current Privacy Policy and Terms of Use:
 
 * **Service**: translate.ultimatemultisite.com
-* **Data Transmitted**: Plugin metadata (name, version, textdomain, site URL, WordPress version)
-* **Data NOT Transmitted**: No personal data, content, or confidential information
-* **Purpose**: Generate AI translations for missing plugin strings
+* **Purpose**: Check language-pack availability and generate requested translations
 * **Terms of Use**: https://ultimatemultisite.com/terms
 * **Privacy Policy**: https://ultimatemultisite.com/privacy
 
-Translations are cached locally on your server. No data is stored on external servers permanently.
+Deactivate the plugin to stop its external requests. Developers can also disable automatic translation checks with the `sd_ai_lang_packs_enabled` filter.
 
 = Features =
 
@@ -51,7 +60,7 @@ Translations are cached locally on your server. No data is stored on external se
 * **Priority System**: Popular plugins get translated first
 * **Caching**: Both API responses and translation files are cached
 * **WP-CLI Support**: Full command-line management
-* **Privacy Friendly**: Only sends plugin metadata, no personal data
+* **Transparent service disclosure**: Documents the installation data sent to the translation service
 
 == Installation ==
 
@@ -87,7 +96,7 @@ This plugin specifically fills the gap in plugin translations. Unlike page trans
 
 = Is my data safe? =
 
-Yes. The plugin only sends plugin metadata (name, version, textdomain) to generate translations. No personal data, user data, or site content is transmitted. All translations are cached locally.
+The plugin sends the site URL, WordPress version, requested locale codes, and limited installed-plugin metadata (text domain, version, and update source) to the translation service. It does not include user IDs, names, email addresses, passwords, site content, posts, comments, or database records in its request body. The service also receives the connection IP address as part of handling an HTTP request. Read the linked Privacy Policy and Terms of Use before activating the plugin.
 
 = What languages are supported? =
 
@@ -136,14 +145,8 @@ Initial release. No upgrade necessary.
 
 == Privacy Policy ==
 
-This plugin communicates with translate.ultimatemultisite.com to generate translations. The following data is transmitted:
+This plugin communicates with translate.ultimatemultisite.com to check language-pack availability and request translations. It sends plugin text domains, plugin versions, plugin update-source classification, requested locale codes, the site URL, and the WordPress version. The request body does not include user IDs, names, email addresses, passwords, site content, posts, comments, or database records.
 
-* Plugin textdomain (e.g., "woocommerce")
-* Plugin version
-* Site URL
-* WordPress version
-* Requested locale
+The site URL and connection IP address may identify an installation. The plugin stores its own cache and downloaded language packs locally; the service provider's processing and retention practices are described in its Privacy Policy: https://ultimatemultisite.com/privacy
 
-This data is used solely to generate translations and is not stored permanently. Translations are cached locally on your server.
-
-For more information, see our full Privacy Policy at https://ultimatemultisite.com/privacy
+You can stop plugin requests by deactivating the plugin. Developers can disable automatic translation checks with the `sd_ai_lang_packs_enabled` filter.

--- a/readme.txt
+++ b/readme.txt
@@ -31,16 +31,15 @@ The official WordPress translation platform (translate.wordpress.org) relies on 
 
 = External Service Usage =
 
-This plugin requires the translation service at https://translate.ultimatemultisite.com to check availability and request AI-generated plugin language packs. Requests are made automatically after activation and during scheduled translation checks when the plugin is enabled.
+This plugin requires the translation service at https://translate.ultimatemultisite.com to check availability and request AI-generated plugin language packs. Requests are made automatically after activation and during scheduled translation checks.
 
 The service receives:
 
 * Plugin text domain and installed version for plugins that need a language pack
-* Whether each plugin uses WordPress.org updates or another update source
 * Requested locale codes, including locales discovered from site, network-site, and user-profile language settings
-* The site's URL and WordPress version
+* Plugin update-source classification when it is available
 
-The request body does not include user IDs, names, email addresses, passwords, site content, posts, comments, or database records. However, a site URL and the connection IP address received by the service can identify an installation and should be treated as installation data.
+The request body does not include the site URL, WordPress version, user IDs, names, email addresses, passwords, site content, posts, comments, or database records. The service receives the connection IP address as part of handling an HTTP request.
 
 The plugin stores its cache and downloaded language packs locally. The service provider's handling, retention, and deletion of request data are governed by its current Privacy Policy and Terms of Use:
 
@@ -49,7 +48,7 @@ The plugin stores its cache and downloaded language packs locally. The service p
 * **Terms of Use**: https://ultimatemultisite.com/terms
 * **Privacy Policy**: https://ultimatemultisite.com/privacy
 
-Deactivate the plugin to stop its external requests. Developers can also disable automatic translation checks with the `sd_ai_lang_packs_enabled` filter.
+Deactivate the plugin to stop its external requests.
 
 = Features =
 
@@ -96,7 +95,7 @@ This plugin specifically fills the gap in plugin translations. Unlike page trans
 
 = Is my data safe? =
 
-The plugin sends the site URL, WordPress version, requested locale codes, and limited installed-plugin metadata (text domain, version, and update source) to the translation service. It does not include user IDs, names, email addresses, passwords, site content, posts, comments, or database records in its request body. The service also receives the connection IP address as part of handling an HTTP request. Read the linked Privacy Policy and Terms of Use before activating the plugin.
+The plugin sends requested locale codes and limited installed-plugin metadata (text domain, version, and update source when available) to the translation service. It does not include the site URL, WordPress version, user IDs, names, email addresses, passwords, site content, posts, comments, or database records in its request body. The service receives the connection IP address as part of handling an HTTP request. Read the linked Privacy Policy and Terms of Use before activating the plugin.
 
 = What languages are supported? =
 
@@ -145,8 +144,8 @@ Initial release. No upgrade necessary.
 
 == Privacy Policy ==
 
-This plugin communicates with translate.ultimatemultisite.com to check language-pack availability and request translations. It sends plugin text domains, plugin versions, plugin update-source classification, requested locale codes, the site URL, and the WordPress version. The request body does not include user IDs, names, email addresses, passwords, site content, posts, comments, or database records.
+This plugin communicates with translate.ultimatemultisite.com to check language-pack availability and request translations. It sends plugin text domains, plugin versions, plugin update-source classification when available, and requested locale codes. The request body does not include the site URL, WordPress version, user IDs, names, email addresses, passwords, site content, posts, comments, or database records.
 
-The site URL and connection IP address may identify an installation. The plugin stores its own cache and downloaded language packs locally; the service provider's processing and retention practices are described in its Privacy Policy: https://ultimatemultisite.com/privacy
+The service receives the connection IP address as part of handling an HTTP request. The plugin stores its own cache and downloaded language packs locally; the service provider's processing and retention practices are described in its Privacy Policy: https://ultimatemultisite.com/privacy
 
-You can stop plugin requests by deactivating the plugin. Developers can disable automatic translation checks with the `sd_ai_lang_packs_enabled` filter.
+You can stop plugin requests by deactivating the plugin.

--- a/src/class-admin-settings.php
+++ b/src/class-admin-settings.php
@@ -162,9 +162,8 @@ class Admin_Settings {
 	 * @return void
 	 */
 	public function render_status_page(): void {
-		$enabled           = (bool) apply_filters( 'sd_ai_lang_packs_enabled', true );
-		$api_status        = $enabled ? $this->api_client->check_api_status() : null;
-		$api_healthy       = $enabled && ! is_wp_error( $api_status );
+		$api_status        = $this->api_client->check_api_status();
+		$api_healthy       = ! is_wp_error( $api_status );
 		$local             = $this->get_local_translation_details();
 		$stats             = $this->get_translation_statistics( $local );
 		$plugin_names      = $this->get_plugin_name_map();
@@ -182,12 +181,7 @@ class Admin_Settings {
 
 			<div class="card">
 				<h2><?php esc_html_e( 'Service Status', 'superdav-ai-language-packs' ); ?></h2>
-				<?php if ( ! $enabled ) : ?>
-					<p class="sd-ai-lang-packs-status-line">
-						<span class="dashicons dashicons-minus" aria-hidden="true"></span>
-						<?php esc_html_e( 'Automatic translation checks are disabled. This page has not contacted the translation service.', 'superdav-ai-language-packs' ); ?>
-					</p>
-				<?php elseif ( $api_healthy ) : ?>
+				<?php if ( $api_healthy ) : ?>
 					<p class="sd-ai-lang-packs-status-line">
 						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
 						<?php esc_html_e( 'Translation service is online and ready.', 'superdav-ai-language-packs' ); ?>
@@ -376,18 +370,18 @@ class Admin_Settings {
 				<h2><?php esc_html_e( 'Privacy Notice', 'superdav-ai-language-packs' ); ?></h2>
 				<p><?php esc_html_e( 'This plugin uses the translation service to check language-pack availability and request translations. The service receives the following installation data:', 'superdav-ai-language-packs' ); ?></p>
 				<ul>
-					<li><?php esc_html_e( 'Plugin text domains, installed versions, and update-source classification', 'superdav-ai-language-packs' ); ?></li>
+					<li><?php esc_html_e( 'Plugin text domains and installed versions', 'superdav-ai-language-packs' ); ?></li>
 					<li><?php esc_html_e( 'Requested locale codes, including locales discovered from site, network-site, and user-profile language settings', 'superdav-ai-language-packs' ); ?></li>
-					<li><?php esc_html_e( 'The site URL and WordPress version', 'superdav-ai-language-packs' ); ?></li>
+					<li><?php esc_html_e( 'Plugin update-source classification when it is available', 'superdav-ai-language-packs' ); ?></li>
 				</ul>
-				<p><?php esc_html_e( 'The request body does not include user IDs, names, email addresses, passwords, site content, posts, comments, or database records. The site URL and connection IP address received by the service can identify an installation.', 'superdav-ai-language-packs' ); ?></p>
+				<p><?php esc_html_e( 'The request body does not include the site URL, WordPress version, user IDs, names, email addresses, passwords, site content, posts, comments, or database records. The service receives the connection IP address as part of handling an HTTP request.', 'superdav-ai-language-packs' ); ?></p>
 				<p><?php esc_html_e( 'The plugin stores its cache and downloaded language packs locally. The service provider handles request data under its current terms and privacy policy.', 'superdav-ai-language-packs' ); ?></p>
 				<p class="sd-ai-lang-packs-muted">
 					<a href="<?php echo esc_url( 'https://ultimatemultisite.com/terms' ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Terms of Use', 'superdav-ai-language-packs' ); ?></a>
 					<?php echo esc_html_x( '·', 'separator between external policy links', 'superdav-ai-language-packs' ); ?>
 					<a href="<?php echo esc_url( 'https://ultimatemultisite.com/privacy' ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Privacy Policy', 'superdav-ai-language-packs' ); ?></a>
 				</p>
-				<p class="sd-ai-lang-packs-muted"><?php esc_html_e( 'Deactivate the plugin to stop its external requests. Developers can disable automatic translation checks with the sd_ai_lang_packs_enabled filter.', 'superdav-ai-language-packs' ); ?></p>
+				<p class="sd-ai-lang-packs-muted"><?php esc_html_e( 'Deactivate the plugin to stop its external requests.', 'superdav-ai-language-packs' ); ?></p>
 			</div>
 		</div>
 		<?php

--- a/src/class-admin-settings.php
+++ b/src/class-admin-settings.php
@@ -162,8 +162,9 @@ class Admin_Settings {
 	 * @return void
 	 */
 	public function render_status_page(): void {
-		$api_status        = $this->api_client->check_api_status();
-		$api_healthy       = ! is_wp_error( $api_status );
+		$enabled           = (bool) apply_filters( 'sd_ai_lang_packs_enabled', true );
+		$api_status        = $enabled ? $this->api_client->check_api_status() : null;
+		$api_healthy       = $enabled && ! is_wp_error( $api_status );
 		$local             = $this->get_local_translation_details();
 		$stats             = $this->get_translation_statistics( $local );
 		$plugin_names      = $this->get_plugin_name_map();
@@ -181,7 +182,12 @@ class Admin_Settings {
 
 			<div class="card">
 				<h2><?php esc_html_e( 'Service Status', 'superdav-ai-language-packs' ); ?></h2>
-				<?php if ( $api_healthy ) : ?>
+				<?php if ( ! $enabled ) : ?>
+					<p class="sd-ai-lang-packs-status-line">
+						<span class="dashicons dashicons-minus" aria-hidden="true"></span>
+						<?php esc_html_e( 'Automatic translation checks are disabled. This page has not contacted the translation service.', 'superdav-ai-language-packs' ); ?>
+					</p>
+				<?php elseif ( $api_healthy ) : ?>
 					<p class="sd-ai-lang-packs-status-line">
 						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
 						<?php esc_html_e( 'Translation service is online and ready.', 'superdav-ai-language-packs' ); ?>
@@ -368,12 +374,20 @@ class Admin_Settings {
 
 			<div class="card">
 				<h2><?php esc_html_e( 'Privacy Notice', 'superdav-ai-language-packs' ); ?></h2>
-				<p><?php esc_html_e( 'This plugin sends plugin metadata (name, version, textdomain), the requested locale, the site URL, and the WordPress version to the translation service. No personal data, user data, or site content is transmitted. Translations are cached on your server.', 'superdav-ai-language-packs' ); ?></p>
+				<p><?php esc_html_e( 'This plugin uses the translation service to check language-pack availability and request translations. The service receives the following installation data:', 'superdav-ai-language-packs' ); ?></p>
+				<ul>
+					<li><?php esc_html_e( 'Plugin text domains, installed versions, and update-source classification', 'superdav-ai-language-packs' ); ?></li>
+					<li><?php esc_html_e( 'Requested locale codes, including locales discovered from site, network-site, and user-profile language settings', 'superdav-ai-language-packs' ); ?></li>
+					<li><?php esc_html_e( 'The site URL and WordPress version', 'superdav-ai-language-packs' ); ?></li>
+				</ul>
+				<p><?php esc_html_e( 'The request body does not include user IDs, names, email addresses, passwords, site content, posts, comments, or database records. The site URL and connection IP address received by the service can identify an installation.', 'superdav-ai-language-packs' ); ?></p>
+				<p><?php esc_html_e( 'The plugin stores its cache and downloaded language packs locally. The service provider handles request data under its current terms and privacy policy.', 'superdav-ai-language-packs' ); ?></p>
 				<p class="sd-ai-lang-packs-muted">
 					<a href="<?php echo esc_url( 'https://ultimatemultisite.com/terms' ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Terms of Use', 'superdav-ai-language-packs' ); ?></a>
 					<?php echo esc_html_x( '·', 'separator between external policy links', 'superdav-ai-language-packs' ); ?>
 					<a href="<?php echo esc_url( 'https://ultimatemultisite.com/privacy' ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Privacy Policy', 'superdav-ai-language-packs' ); ?></a>
 				</p>
+				<p class="sd-ai-lang-packs-muted"><?php esc_html_e( 'Deactivate the plugin to stop its external requests. Developers can disable automatic translation checks with the sd_ai_lang_packs_enabled filter.', 'superdav-ai-language-packs' ); ?></p>
 			</div>
 		</div>
 		<?php

--- a/src/class-translation-api-client.php
+++ b/src/class-translation-api-client.php
@@ -94,8 +94,6 @@ class Translation_API_Client {
                     'plugins'    => array_values($plugins),
                     'locales'    => array_values($locales),
                     'auto_approve' => false,  // Default: require approval
-                    'site_url'   => get_site_url(),
-                    'wp_version' => get_bloginfo('version'),
                 ]),
             ]
         );

--- a/src/class-translation-manager.php
+++ b/src/class-translation-manager.php
@@ -100,10 +100,6 @@ class Translation_Manager {
      * @return void
      */
     public function refresh_translations_cache(): void {
-        if (!$this->is_enabled()) {
-            return;
-        }
-
         if (!function_exists('get_plugins')) {
             require_once ABSPATH . 'wp-admin/includes/plugin.php';
         }
@@ -388,7 +384,7 @@ class Translation_Manager {
      * @return array|bool Modified result.
      */
     public function filter_translations_api($result, string $type, $args) {
-        if ($type !== 'plugins' || !$this->is_enabled()) {
+        if ($type !== 'plugins') {
             return $result;
         }
 
@@ -763,25 +759,6 @@ class Translation_Manager {
     }
 
     /**
-     * Check if the plugin is enabled.
-     *
-     * @since 1.0.0
-     * @return bool True if enabled.
-     */
-    private function is_enabled(): bool {
-        /**
-         * Filter whether the plugin is enabled.
-         *
-         * Allows site owners to disable via code (e.g. a mu-plugin) without
-         * a settings page. Default: true.
-         *
-         * @since 1.0.0
-         * @param bool $enabled Default true.
-         */
-        return (bool) apply_filters('sd_ai_lang_packs_enabled', true);
-    }
-
-    /**
      * Schedule async translation request after profile change.
      *
      * Defers the slow API/network work to wp-cron so the profile save
@@ -792,9 +769,6 @@ class Translation_Manager {
      * @return void
      */
     public function schedule_translation_request_for_user(int $user_id): void {
-        if (!$this->is_enabled()) {
-            return;
-        }
         $locale = get_user_meta($user_id, 'locale', true);
         if (!is_string($locale)) {
             return;
@@ -820,10 +794,6 @@ class Translation_Manager {
      * @return void
      */
     public function maybe_request_translations_for_user(int $user_id): void {
-        if (!$this->is_enabled()) {
-            return;
-        }
-
         $locale = get_user_meta($user_id, 'locale', true);
         if (!is_string($locale)) {
             return;


### PR DESCRIPTION
## Summary

- stop sending the site URL and WordPress version in batch requests
- disclose the remaining request data consistently in the listing, repository documentation, and wp-admin
- remove the unused `sd_ai_lang_packs_enabled` filter; deactivation is the opt-out path
- include runtime CSS assets in Composer release archives
- replace `%i` table placeholders with quoted, WordPress-generated identifiers to retain WordPress 5.8 compatibility

## Verification

- `php -l superdav-ai-language-packs.php`
- `php -l src/class-admin-settings.php`
- `php -l src/class-locale-discovery.php`
- `php -l src/class-translation-api-client.php`
- `php -l src/class-translation-manager.php`
- `composer build`
- `unzip -t superdav-ai-language-packs.zip`
- verified the archive contains `assets/admin.css` and `assets/admin.min.css`
- verified no SQL string in `src/class-locale-discovery.php` uses `%i`

Resolves #52

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.127 plugin for [OpenCode](https://opencode.ai) v1.18.2
