### PR TITLE
fix: install Subversion in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,9 @@ jobs:
           echo "stage_dir=${stage_dir}" >> "${GITHUB_OUTPUT}"
           echo "archive=${archive}" >> "${GITHUB_OUTPUT}"
 
+      - name: Install Subversion
+        run: sudo apt-get update && sudo apt-get install --yes subversion
+
       - name: Deploy to WordPress.org SVN
         env:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}


### PR DESCRIPTION
## Summary

- Installs Subversion before the WordPress.org deployment step.
- Fixes the terminal failure from the `v1.0.1` release run, where the hosted runner did not provide the `svn` executable.

## Verification

- YAML parse succeeded.
- The failed run showed `svn: command not found` before any SVN checkout or repository write occurred.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.148 plugin for [OpenCode](https://opencode.ai) v1.18.3
