### PR TITLE
fix: commit scheduled SVN changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
             svn delete --force "${path}"
           done < <(svn status "${svn_dir}/trunk" | awk '/^!/ { $1 = ""; sub(/^ /, ""); print }')
 
-          if svn status --quiet "${svn_dir}/trunk" | grep -q .; then
+          if svn status "${svn_dir}/trunk" | grep -q .; then
             svn commit "${svn_dir}/trunk" \
               --username "${SVN_USERNAME}" \
               --password "${SVN_PASSWORD}" \


### PR DESCRIPTION
## Summary

- Detects scheduled SVN additions and deletions with `svn status` before committing trunk.
- Fixes the terminal `v1.0.1` deployment failure: `svn status --quiet` suppressed the scheduled additions, leaving trunk empty before the tag copy.

## Verification

- YAML parse succeeded.
- An isolated checkout of the approved SVN repository confirmed that `svn status` reports a scheduled addition.
- The failed run did not commit trunk or create the `1.0.1` SVN tag.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.32.148 plugin for [OpenCode](https://opencode.ai) v1.18.3
